### PR TITLE
homebrew path for Apple Silicon Macs

### DIFF
--- a/BUILDING_OSX.md
+++ b/BUILDING_OSX.md
@@ -30,7 +30,7 @@ brew install coreutils cmake giflib jpeg-turbo libpng ninja zlib
 ```
 
 Before building the project check that `which clang` is
-`/usr/local/opt/llvm/bin/clang`, not the one provided by XCode. If not, update
+`/usr/local/opt/llvm/bin/clang` (or `/opt/homebrew/opt/llvm/bin/clang` on Apple Silicon Macs), not the one provided by XCode. If not, update
 `PATH` environment variable.
 
 Also, setting `CMAKE_PREFIX_PATH` might be necessary for correct include paths


### PR DESCRIPTION

### Description

Homebrew on Apple Silicon uses a different path. Adding this detail.

### Pull Request Checklist

- ✅ **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- ✅ **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- ✅ **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/google/jpegli/blob/main/CONTRIBUTING.md) for more details.
