### PR TITLE
warning instead of error for invalid icc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -93,3 +93,4 @@ xiota
 Yonatan Nebenzhal <yonatan.nebenzhl@gmail.com>
 Ziemowit Zabawa <ziemek.zabawa@outlook.com>
 源文雨 <41315874+fumiama@users.noreply.github.com>
+Mert Alev <101130780+mertalev@users.noreply.github.com>

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -409,24 +409,29 @@ void ProcessAPP(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
       payload += sizeof(kIccProfileTag);
       payload_size -= sizeof(kIccProfileTag);
       if (payload_size < 2) {
-        JPEGLI_ERROR("ICC chunk is too small.");
+        JPEGLI_WARN("ICC chunk is too small.");
+        return;
       }
       uint8_t index = payload[0];
       uint8_t total = payload[1];
       ++m->icc_index_;
       if (m->icc_index_ != index) {
-        JPEGLI_ERROR("Invalid ICC chunk order.");
+        JPEGLI_WARN("Invalid ICC chunk order.");
+        return;
       }
       if (total == 0) {
-        JPEGLI_ERROR("Invalid ICC chunk total.");
+        JPEGLI_WARN("Invalid ICC chunk total.");
+        return;
       }
       if (m->icc_total_ == 0) {
         m->icc_total_ = total;
       } else if (m->icc_total_ != total) {
-        JPEGLI_ERROR("Invalid ICC chunk total.");
+        JPEGLI_WARN("Invalid ICC chunk total.");
+        return;
       }
       if (m->icc_index_ > m->icc_total_) {
-        JPEGLI_ERROR("Invalid ICC chunk index.");
+        JPEGLI_WARN("Invalid ICC chunk index.");
+        return;
       }
       m->icc_profile_.insert(m->icc_profile_.end(), payload + 2,
                              payload + payload_size);


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `jpegli`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

Some JPEG images in the wild have invalid ICC profiles despite being otherwise valid images. See [this](https://github.com/immich-app/immich/issues/13603) issue for an example of a phone that systematically produces such images. As these images can be decoded without issue, simply emitting a warning and ignoring the ICC profile is a better behavior than crashing.

Tested with [this](https://www.dropbox.com/scl/fi/o1xthjmhof5p7w5gezqmn/IMG_20241030_200839581.jpg?rlkey=lxhbmrp1k3d93562pcd43i0vm&st=f9o7wydk&dl=0) sample image and confirmed that it was processed successfully with this change, but failed without it.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/google/jpegli/blob/main/CONTRIBUTING.md) for more details.
