### PR TITLE
Remove usage of obsolete macro `c_plusplus`

### DIFF
--- a/lib/jpegli/common.h
+++ b/lib/jpegli/common.h
@@ -23,7 +23,7 @@
 
 #include "lib/base/include_jpeglib.h"  // NOLINT
 
-#if defined(__cplusplus) || defined(c_plusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -37,7 +37,7 @@ JQUANT_TBL* jpegli_alloc_quant_table(j_common_ptr cinfo);
 
 JHUFF_TBL* jpegli_alloc_huff_table(j_common_ptr cinfo);
 
-#if defined(__cplusplus) || defined(c_plusplus)
+#ifdef __cplusplus
 }  // extern "C"
 #endif
 

--- a/lib/jpegli/decode.h
+++ b/lib/jpegli/decode.h
@@ -24,7 +24,7 @@
 #include "lib/jpegli/common.h"
 #include "lib/jpegli/types.h"
 
-#if defined(__cplusplus) || defined(c_plusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -101,7 +101,7 @@ void jpegli_new_colormap(j_decompress_ptr cinfo);
 void jpegli_set_output_format(j_decompress_ptr cinfo, JpegliDataType data_type,
                               JpegliEndianness endianness);
 
-#if defined(__cplusplus) || defined(c_plusplus)
+#ifdef __cplusplus
 }  // extern "C"
 #endif
 

--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -24,7 +24,7 @@
 #include "lib/jpegli/common.h"
 #include "lib/jpegli/types.h"
 
-#if defined(__cplusplus) || defined(c_plusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -153,7 +153,7 @@ void jpegli_set_progressive_level(j_compress_ptr cinfo, int level);
 // AC coefficients. Must be called before jpegli_set_defaults().
 void jpegli_use_standard_quant_tables(j_compress_ptr cinfo);
 
-#if defined(__cplusplus) || defined(c_plusplus)
+#ifdef __cplusplus
 }  // extern "C"
 #endif
 

--- a/lib/jpegli/types.h
+++ b/lib/jpegli/types.h
@@ -7,7 +7,7 @@
 #ifndef LIB_JPEGLI_TYPES_H_
 #define LIB_JPEGLI_TYPES_H_
 
-#if defined(__cplusplus) || defined(c_plusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -32,7 +32,7 @@ typedef enum {
 
 int jpegli_bytes_per_sample(JpegliDataType data_type);
 
-#if defined(__cplusplus) || defined(c_plusplus)
+#ifdef __cplusplus
 }  // extern "C"
 #endif
 


### PR DESCRIPTION
ported from #3612 from libjxl
