### PR TITLE
Sow MemoryManager (#3561)

### DIFF
--- a/lib/extras/butteraugli.cc
+++ b/lib/extras/butteraugli.cc
@@ -32,6 +32,7 @@
 #include <memory>
 #include <vector>
 
+#include "lib/base/memory_manager.h"
 #include "lib/extras/image.h"
 
 #undef HWY_TARGET_INCLUDE
@@ -410,8 +411,9 @@ Status SeparateMFAndHF(const ButteraugliParams& params, Image3F* mf, ImageF* hf,
   static const double kSigmaHf = 3.22489901262;
   const size_t xsize = mf->xsize();
   const size_t ysize = mf->ysize();
-  JXL_ASSIGN_OR_RETURN(hf[0], ImageF::Create(xsize, ysize));
-  JXL_ASSIGN_OR_RETURN(hf[1], ImageF::Create(xsize, ysize));
+  JxlMemoryManager* memory_manager = mf[0].memory_manager();
+  JXL_ASSIGN_OR_RETURN(hf[0], ImageF::Create(memory_manager, xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(hf[1], ImageF::Create(memory_manager, xsize, ysize));
   for (int i = 0; i < 3; ++i) {
     if (i == 2) {
       JXL_RETURN_IF_ERROR(
@@ -466,9 +468,10 @@ Status SeparateHFAndUHF(const ButteraugliParams& params, ImageF* hf,
   const HWY_FULL(float) d;
   const size_t xsize = hf[0].xsize();
   const size_t ysize = hf[0].ysize();
+  JxlMemoryManager* memory_manager = hf[0].memory_manager();
   static const double kSigmaUhf = 1.56416327805;
-  JXL_ASSIGN_OR_RETURN(uhf[0], ImageF::Create(xsize, ysize));
-  JXL_ASSIGN_OR_RETURN(uhf[1], ImageF::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(uhf[0], ImageF::Create(memory_manager, xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(uhf[1], ImageF::Create(memory_manager, xsize, ysize));
   for (int i = 0; i < 2; ++i) {
     // Divide hf into hf and uhf.
     for (size_t y = 0; y < ysize; ++y) {
@@ -532,8 +535,11 @@ void DeallocateHFAndUHF(ImageF* hf, ImageF* uhf) {
 Status SeparateFrequencies(size_t xsize, size_t ysize,
                            const ButteraugliParams& params, BlurTemp* blur_temp,
                            const Image3F& xyb, PsychoImage& ps) {
-  JXL_ASSIGN_OR_RETURN(ps.lf, Image3F::Create(xyb.xsize(), xyb.ysize()));
-  JXL_ASSIGN_OR_RETURN(ps.mf, Image3F::Create(xyb.xsize(), xyb.ysize()));
+  JxlMemoryManager* memory_manager = xyb.memory_manager();
+  JXL_ASSIGN_OR_RETURN(
+      ps.lf, Image3F::Create(memory_manager, xyb.xsize(), xyb.ysize()));
+  JXL_ASSIGN_OR_RETURN(
+      ps.mf, Image3F::Create(memory_manager, xyb.xsize(), xyb.ysize()));
   JXL_RETURN_IF_ERROR(SeparateLFAndMF(params, xyb, &ps.lf, &ps.mf, blur_temp));
   JXL_RETURN_IF_ERROR(SeparateMFAndHF(params, &ps.mf, &ps.hf[0], blur_temp));
   JXL_RETURN_IF_ERROR(
@@ -1205,14 +1211,19 @@ Status Mask(const ImageF& mask0, const ImageF& mask1,
             ImageF* BUTTERAUGLI_RESTRICT diff_ac) {
   const size_t xsize = mask0.xsize();
   const size_t ysize = mask0.ysize();
-  JXL_ASSIGN_OR_RETURN(*mask, ImageF::Create(xsize, ysize));
+  JxlMemoryManager* memory_manager = mask0.memory_manager();
+  JXL_ASSIGN_OR_RETURN(*mask, ImageF::Create(memory_manager, xsize, ysize));
   static const float kMul = 6.19424080439;
   static const float kBias = 12.61050594197;
   static const float kRadius = 2.7;
-  JXL_ASSIGN_OR_RETURN(ImageF diff0, ImageF::Create(xsize, ysize));
-  JXL_ASSIGN_OR_RETURN(ImageF diff1, ImageF::Create(xsize, ysize));
-  JXL_ASSIGN_OR_RETURN(ImageF blurred0, ImageF::Create(xsize, ysize));
-  JXL_ASSIGN_OR_RETURN(ImageF blurred1, ImageF::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(ImageF diff0,
+                       ImageF::Create(memory_manager, xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(ImageF diff1,
+                       ImageF::Create(memory_manager, xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(ImageF blurred0,
+                       ImageF::Create(memory_manager, xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(ImageF blurred1,
+                       ImageF::Create(memory_manager, xsize, ysize));
   DiffPrecompute(mask0, kMul, kBias, &diff0);
   DiffPrecompute(mask1, kMul, kBias, &diff1);
   JXL_RETURN_IF_ERROR(Blur(diff0, kRadius, params, blur_temp, &blurred0));
@@ -1237,8 +1248,11 @@ Status MaskPsychoImage(const PsychoImage& pi0, const PsychoImage& pi1,
                        const ButteraugliParams& params, BlurTemp* blur_temp,
                        ImageF* BUTTERAUGLI_RESTRICT mask,
                        ImageF* BUTTERAUGLI_RESTRICT diff_ac) {
-  JXL_ASSIGN_OR_RETURN(ImageF mask0, ImageF::Create(xsize, ysize));
-  JXL_ASSIGN_OR_RETURN(ImageF mask1, ImageF::Create(xsize, ysize));
+  JxlMemoryManager* memory_manager = pi0.hf[0].memory_manager();
+  JXL_ASSIGN_OR_RETURN(ImageF mask0,
+                       ImageF::Create(memory_manager, xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(ImageF mask1,
+                       ImageF::Create(memory_manager, xsize, ysize));
   CombineChannelsForMasking(&pi0.hf[0], &pi0.uhf[0], &mask0);
   CombineChannelsForMasking(&pi1.hf[0], &pi1.uhf[0], &mask1);
   JXL_RETURN_IF_ERROR(Mask(mask0, mask1, params, blur_temp, mask, diff_ac));
@@ -1522,23 +1536,28 @@ Status ButteraugliDiffmapInPlace(Image3F& image0, Image3F& image1,
   // image0 and image1 are in linear sRGB color space
   const size_t xsize = image0.xsize();
   const size_t ysize = image0.ysize();
+  JxlMemoryManager* memory_manager = image0.memory_manager();
   BlurTemp blur_temp;
   {
     // Convert image0 and image1 to XYB in-place
-    JXL_ASSIGN_OR_RETURN(Image3F temp, Image3F::Create(xsize, ysize));
+    JXL_ASSIGN_OR_RETURN(Image3F temp,
+                         Image3F::Create(memory_manager, xsize, ysize));
     JXL_RETURN_IF_ERROR(
         OpsinDynamicsImage(image0, params, &temp, &blur_temp, &image0));
     JXL_RETURN_IF_ERROR(
         OpsinDynamicsImage(image1, params, &temp, &blur_temp, &image1));
   }
   // image0 and image1 are in XYB color space
-  JXL_ASSIGN_OR_RETURN(ImageF block_diff_dc, ImageF::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(ImageF block_diff_dc,
+                       ImageF::Create(memory_manager, xsize, ysize));
   ZeroFillImage(&block_diff_dc);
   {
     // separate out LF components from image0 and image1 and compute the dc
     // diff image from them
-    JXL_ASSIGN_OR_RETURN(Image3F lf0, Image3F::Create(xsize, ysize));
-    JXL_ASSIGN_OR_RETURN(Image3F lf1, Image3F::Create(xsize, ysize));
+    JXL_ASSIGN_OR_RETURN(Image3F lf0,
+                         Image3F::Create(memory_manager, xsize, ysize));
+    JXL_ASSIGN_OR_RETURN(Image3F lf1,
+                         Image3F::Create(memory_manager, xsize, ysize));
     JXL_RETURN_IF_ERROR(
         SeparateLFAndMF(params, image0, &lf0, &image0, &blur_temp));
     JXL_RETURN_IF_ERROR(
@@ -1554,11 +1573,13 @@ Status ButteraugliDiffmapInPlace(Image3F& image0, Image3F& image1,
   JXL_RETURN_IF_ERROR(SeparateMFAndHF(params, &image1, &hf1[0], &blur_temp));
   // image0 and image1 are MF-images in XYB color space
 
-  JXL_ASSIGN_OR_RETURN(ImageF block_diff_ac, ImageF::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(ImageF block_diff_ac,
+                       ImageF::Create(memory_manager, xsize, ysize));
   ZeroFillImage(&block_diff_ac);
   // start accumulating ac diff image from MF images
   {
-    JXL_ASSIGN_OR_RETURN(ImageF diffs, ImageF::Create(xsize, ysize));
+    JXL_ASSIGN_OR_RETURN(ImageF diffs,
+                         ImageF::Create(memory_manager, xsize, ysize));
     MaltaDiffMapLF(image0.Plane(1), image1.Plane(1), wMfMalta, wMfMalta,
                    norm1Mf, &diffs, &block_diff_ac);
     MaltaDiffMapLF(image0.Plane(0), image1.Plane(0), wMfMaltaX, wMfMaltaX,
@@ -1580,7 +1601,8 @@ Status ButteraugliDiffmapInPlace(Image3F& image0, Image3F& image1,
   // continue accumulating ac diff image from HF and UHF images
   const float hf_asymmetry = params.hf_asymmetry;
   {
-    JXL_ASSIGN_OR_RETURN(ImageF diffs, ImageF::Create(xsize, ysize));
+    JXL_ASSIGN_OR_RETURN(ImageF diffs,
+                         ImageF::Create(memory_manager, xsize, ysize));
     MaltaDiffMap(uhf0[1], uhf1[1], wUhfMalta * hf_asymmetry,
                  wUhfMalta / hf_asymmetry, norm1Uhf, &diffs, &block_diff_ac);
     MaltaDiffMap(uhf0[0], uhf1[0], wUhfMaltaX * hf_asymmetry,
@@ -1598,10 +1620,13 @@ Status ButteraugliDiffmapInPlace(Image3F& image0, Image3F& image1,
   }
 
   // compute mask image from HF and UHF X and Y images
-  JXL_ASSIGN_OR_RETURN(ImageF mask, ImageF::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(ImageF mask,
+                       ImageF::Create(memory_manager, xsize, ysize));
   {
-    JXL_ASSIGN_OR_RETURN(ImageF mask0, ImageF::Create(xsize, ysize));
-    JXL_ASSIGN_OR_RETURN(ImageF mask1, ImageF::Create(xsize, ysize));
+    JXL_ASSIGN_OR_RETURN(ImageF mask0,
+                         ImageF::Create(memory_manager, xsize, ysize));
+    JXL_ASSIGN_OR_RETURN(ImageF mask1,
+                         ImageF::Create(memory_manager, xsize, ysize));
     CombineChannelsForMasking(&hf0[0], &uhf0[0], &mask0);
     CombineChannelsForMasking(&hf1[0], &uhf1[0], &mask1);
     DeallocateHFAndUHF(&hf1[0], &uhf1[0]);
@@ -1611,7 +1636,7 @@ Status ButteraugliDiffmapInPlace(Image3F& image0, Image3F& image1,
   }
 
   // compute final diffmap from mask image and ac and dc diff images
-  JXL_ASSIGN_OR_RETURN(diffmap, ImageF::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(diffmap, ImageF::Create(memory_manager, xsize, ysize));
   for (size_t y = 0; y < ysize; ++y) {
     const float* row_dc = block_diff_dc.Row(y);
     const float* row_ac = block_diff_ac.Row(y);
@@ -1695,7 +1720,8 @@ static inline void CheckImage(const ImageF& image, const char* name) {
 static StatusOr<Image3F> SubSample2x(const Image3F& in) {
   size_t xs = (in.xsize() + 1) / 2;
   size_t ys = (in.ysize() + 1) / 2;
-  JXL_ASSIGN_OR_RETURN(Image3F retval, Image3F::Create(xs, ys));
+  JxlMemoryManager* memory_manager = in.memory_manager();
+  JXL_ASSIGN_OR_RETURN(Image3F retval, Image3F::Create(memory_manager, xs, ys));
   for (size_t c = 0; c < 3; ++c) {
     for (size_t y = 0; y < ys; ++y) {
       for (size_t x = 0; x < xs; ++x) {
@@ -1755,16 +1781,19 @@ StatusOr<std::unique_ptr<ButteraugliComparator>> ButteraugliComparator::Make(
     const Image3F& rgb0, const ButteraugliParams& params) {
   size_t xsize = rgb0.xsize();
   size_t ysize = rgb0.ysize();
+  JxlMemoryManager* memory_manager = rgb0.memory_manager();
   std::unique_ptr<ButteraugliComparator> result =
       std::unique_ptr<ButteraugliComparator>(
           new ButteraugliComparator(xsize, ysize, params));
-  JXL_ASSIGN_OR_RETURN(result->temp_, Image3F::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(result->temp_,
+                       Image3F::Create(memory_manager, xsize, ysize));
 
   if (xsize < 8 || ysize < 8) {
     return result;
   }
 
-  JXL_ASSIGN_OR_RETURN(Image3F xyb0, Image3F::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(Image3F xyb0,
+                       Image3F::Create(memory_manager, xsize, ysize));
   JXL_RETURN_IF_ERROR(HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)(
       rgb0, params, result->Temp(), &result->blur_temp_, &xyb0));
   result->ReleaseTemp();
@@ -1790,11 +1819,13 @@ Status ButteraugliComparator::Mask(ImageF* BUTTERAUGLI_RESTRICT mask) const {
 
 Status ButteraugliComparator::Diffmap(const Image3F& rgb1,
                                       ImageF& result) const {
+  JxlMemoryManager* memory_manager = rgb1.memory_manager();
   if (xsize_ < 8 || ysize_ < 8) {
     ZeroFillImage(&result);
     return true;
   }
-  JXL_ASSIGN_OR_RETURN(Image3F xyb1, Image3F::Create(xsize_, ysize_));
+  JXL_ASSIGN_OR_RETURN(Image3F xyb1,
+                       Image3F::Create(memory_manager, xsize_, ysize_));
   JXL_RETURN_IF_ERROR(HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)(
       rgb1, params_, Temp(), &blur_temp_, &xyb1));
   ReleaseTemp();
@@ -1803,8 +1834,9 @@ Status ButteraugliComparator::Diffmap(const Image3F& rgb1,
     if (sub_->xsize_ < 8 || sub_->ysize_ < 8) {
       return true;
     }
-    JXL_ASSIGN_OR_RETURN(Image3F sub_xyb,
-                         Image3F::Create(sub_->xsize_, sub_->ysize_));
+    JXL_ASSIGN_OR_RETURN(
+        Image3F sub_xyb,
+        Image3F::Create(memory_manager, sub_->xsize_, sub_->ysize_));
     JXL_ASSIGN_OR_RETURN(Image3F subsampledRgb1, SubSample2x(rgb1));
     JXL_RETURN_IF_ERROR(HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)(
         subsampledRgb1, params_, sub_->Temp(), &sub_->blur_temp_, &sub_xyb));
@@ -1818,6 +1850,7 @@ Status ButteraugliComparator::Diffmap(const Image3F& rgb1,
 
 Status ButteraugliComparator::DiffmapOpsinDynamicsImage(const Image3F& xyb1,
                                                         ImageF& result) const {
+  JxlMemoryManager* memory_manager = xyb1.memory_manager();
   if (xsize_ < 8 || ysize_ < 8) {
     ZeroFillImage(&result);
     return true;
@@ -1825,7 +1858,7 @@ Status ButteraugliComparator::DiffmapOpsinDynamicsImage(const Image3F& xyb1,
   PsychoImage pi1;
   JXL_RETURN_IF_ERROR(HWY_DYNAMIC_DISPATCH(SeparateFrequencies)(
       xsize_, ysize_, params_, &blur_temp_, xyb1, pi1));
-  JXL_ASSIGN_OR_RETURN(result, ImageF::Create(xsize_, ysize_));
+  JXL_ASSIGN_OR_RETURN(result, ImageF::Create(memory_manager, xsize_, ysize_));
   return DiffmapPsychoImage(pi1, result);
 }
 
@@ -1851,6 +1884,7 @@ void MaltaDiffMapLF(const ImageF& lum0, const ImageF& lum1, const double w_0gt1,
 
 Status ButteraugliComparator::DiffmapPsychoImage(const PsychoImage& pi1,
                                                  ImageF& diffmap) const {
+  JxlMemoryManager* memory_manager = diffmap.memory_manager();
   if (xsize_ < 8 || ysize_ < 8) {
     ZeroFillImage(&diffmap);
     return true;
@@ -1859,8 +1893,10 @@ Status ButteraugliComparator::DiffmapPsychoImage(const PsychoImage& pi1,
   const float hf_asymmetry_ = params_.hf_asymmetry;
   const float xmul_ = params_.xmul;
 
-  JXL_ASSIGN_OR_RETURN(ImageF diffs, ImageF::Create(xsize_, ysize_));
-  JXL_ASSIGN_OR_RETURN(Image3F block_diff_ac, Image3F::Create(xsize_, ysize_));
+  JXL_ASSIGN_OR_RETURN(ImageF diffs,
+                       ImageF::Create(memory_manager, xsize_, ysize_));
+  JXL_ASSIGN_OR_RETURN(Image3F block_diff_ac,
+                       Image3F::Create(memory_manager, xsize_, ysize_));
   ZeroFillImage(&block_diff_ac);
   MaltaDiffMap(pi0_.uhf[1], pi1.uhf[1], wUhfMalta * hf_asymmetry_,
                wUhfMalta / hf_asymmetry_, norm1Uhf, &diffs, &block_diff_ac, 1);
@@ -1878,7 +1914,8 @@ Status ButteraugliComparator::DiffmapPsychoImage(const PsychoImage& pi1,
   MaltaDiffMapLF(pi0_.mf.Plane(0), pi1.mf.Plane(0), wMfMaltaX, wMfMaltaX,
                  norm1MfX, &diffs, &block_diff_ac, 0);
 
-  JXL_ASSIGN_OR_RETURN(Image3F block_diff_dc, Image3F::Create(xsize_, ysize_));
+  JXL_ASSIGN_OR_RETURN(Image3F block_diff_dc,
+                       Image3F::Create(memory_manager, xsize_, ysize_));
   for (size_t c = 0; c < 3; ++c) {
     if (c < 2) {  // No blue channel error accumulated at HF.
       HWY_DYNAMIC_DISPATCH(L2DiffAsymmetric)
@@ -1926,6 +1963,7 @@ bool ButteraugliDiffmapSmall(const Image3F& rgb0, const Image3F& rgb1,
                              const ButteraugliParams& params, ImageF& diffmap) {
   const size_t xsize = rgb0.xsize();
   const size_t ysize = rgb0.ysize();
+  JxlMemoryManager* memory_manager = rgb0.memory_manager();
   // Butteraugli values for small (where xsize or ysize is smaller
   // than 8 pixels) images are non-sensical, but most likely it is
   // less disruptive to try to compute something than just give up.
@@ -1934,8 +1972,10 @@ bool ButteraugliDiffmapSmall(const Image3F& rgb0, const Image3F& rgb1,
   size_t yborder = ysize < kMax ? (kMax - ysize) / 2 : 0;
   size_t xscaled = std::max<size_t>(kMax, xsize);
   size_t yscaled = std::max<size_t>(kMax, ysize);
-  JXL_ASSIGN_OR_RETURN(Image3F scaled0, Image3F::Create(xscaled, yscaled));
-  JXL_ASSIGN_OR_RETURN(Image3F scaled1, Image3F::Create(xscaled, yscaled));
+  JXL_ASSIGN_OR_RETURN(Image3F scaled0,
+                       Image3F::Create(memory_manager, xscaled, yscaled));
+  JXL_ASSIGN_OR_RETURN(Image3F scaled1,
+                       Image3F::Create(memory_manager, xscaled, yscaled));
   for (int i = 0; i < 3; ++i) {
     for (size_t y = 0; y < yscaled; ++y) {
       for (size_t x = 0; x < xscaled; ++x) {
@@ -1948,7 +1988,7 @@ bool ButteraugliDiffmapSmall(const Image3F& rgb0, const Image3F& rgb1,
   }
   ImageF diffmap_scaled;
   const bool ok = ButteraugliDiffmap(scaled0, scaled1, params, diffmap_scaled);
-  JXL_ASSIGN_OR_RETURN(diffmap, ImageF::Create(xsize, ysize));
+  JXL_ASSIGN_OR_RETURN(diffmap, ImageF::Create(memory_manager, xsize, ysize));
   for (size_t y = 0; y < ysize; ++y) {
     for (size_t x = 0; x < xsize; ++x) {
       diffmap.Row(y)[x] = diffmap_scaled.Row(y + yborder)[x + xborder];
@@ -2112,8 +2152,10 @@ void ScoreToRgb(double score, double good_threshold, double bad_threshold,
 StatusOr<Image3F> CreateHeatMapImage(const ImageF& distmap,
                                      double good_threshold,
                                      double bad_threshold) {
-  JXL_ASSIGN_OR_RETURN(Image3F heatmap,
-                       Image3F::Create(distmap.xsize(), distmap.ysize()));
+  JxlMemoryManager* memory_manager = distmap.memory_manager();
+  JXL_ASSIGN_OR_RETURN(
+      Image3F heatmap,
+      Image3F::Create(memory_manager, distmap.xsize(), distmap.ysize()));
   for (size_t y = 0; y < distmap.ysize(); ++y) {
     const float* BUTTERAUGLI_RESTRICT row_distmap = distmap.ConstRow(y);
     float* BUTTERAUGLI_RESTRICT row_h0 = heatmap.PlaneRow(0, y);

--- a/lib/extras/butteraugli.h
+++ b/lib/extras/butteraugli.h
@@ -9,14 +9,14 @@
 #ifndef LIB_EXTRAS_BUTTERAUGLI_H_
 #define LIB_EXTRAS_BUTTERAUGLI_H_
 
-#include <stdlib.h>
-#include <string.h>
-
 #include <atomic>
 #include <cstddef>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 
 #include "lib/base/compiler_specific.h"
+#include "lib/base/memory_manager.h"
 #include "lib/base/status.h"
 #include "lib/extras/image.h"
 
@@ -150,9 +150,11 @@ struct PsychoImage {
 // Hold it here and only allocate on demand to reduce memory usage.
 struct BlurTemp {
   Status GetTransposed(const ImageF &in, ImageF **out) {
+    JxlMemoryManager *memory_manager = in.memory_manager();
     if (transposed_temp.xsize() == 0) {
-      JXL_ASSIGN_OR_RETURN(transposed_temp,
-                           ImageF::Create(in.ysize(), in.xsize()));
+      JXL_ASSIGN_OR_RETURN(
+          transposed_temp,
+          ImageF::Create(memory_manager, in.ysize(), in.xsize()));
     }
     *out = &transposed_temp;
     return true;

--- a/lib/extras/dec/decode.h
+++ b/lib/extras/dec/decode.h
@@ -9,11 +9,9 @@
 
 // Facade for image decoders (PNG, PNM, ...).
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <string>
-#include <vector>
 
 #include "lib/base/span.h"
 #include "lib/base/status.h"

--- a/lib/extras/image.h
+++ b/lib/extras/image.h
@@ -21,6 +21,7 @@
 #include <utility>  // std::move
 
 #include "lib/base/compiler_specific.h"
+#include "lib/base/memory_manager.h"
 #include "lib/base/status.h"
 #include "lib/extras/cache_aligned.h"
 
@@ -38,6 +39,7 @@ struct PlaneBase {
         orig_xsize_(0),
         orig_ysize_(0),
         bytes_per_row_(0),
+        memory_manager_(nullptr),
         bytes_(nullptr),
         sizeof_t_(0) {}
 
@@ -51,6 +53,12 @@ struct PlaneBase {
 
   // Move assignment (required for std::vector)
   PlaneBase& operator=(PlaneBase&& other) noexcept = default;
+
+  ~PlaneBase() {
+    if (bytes_.get()) {
+      JXL_CHECK(memory_manager_);
+    }
+  }
 
   void Swap(PlaneBase& other);
 
@@ -74,6 +82,10 @@ struct PlaneBase {
   // NOTE: do not use this for copying rows - the valid xsize may be much less.
   JXL_INLINE size_t bytes_per_row() const { return bytes_per_row_; }
 
+  JXL_INLINE JxlMemoryManager* memory_manager() const {
+    return memory_manager_;
+  }
+
   // Raw access to byte contents, for interfacing with other libraries.
   // Unsigned char instead of char to avoid surprises (sign extension).
   JXL_INLINE uint8_t* bytes() {
@@ -87,7 +99,7 @@ struct PlaneBase {
 
  protected:
   PlaneBase(size_t xsize, size_t ysize, size_t sizeof_t);
-  Status Allocate();
+  Status Allocate(JxlMemoryManager* memory_manager);
 
   // Returns pointer to the start of a row.
   JXL_INLINE void* VoidRow(const size_t y) const {
@@ -109,6 +121,7 @@ struct PlaneBase {
   uint32_t orig_xsize_;
   uint32_t orig_ysize_;
   size_t bytes_per_row_;  // Includes padding.
+  JxlMemoryManager* memory_manager_;
   CacheAlignedUniquePtr bytes_;
   size_t sizeof_t_;
 };
@@ -144,9 +157,10 @@ class Plane : public detail::PlaneBase {
 
   Plane() = default;
 
-  static StatusOr<Plane> Create(const size_t xsize, const size_t ysize) {
+  static StatusOr<Plane> Create(JxlMemoryManager* memory_manager,
+                                const size_t xsize, const size_t ysize) {
     Plane plane(xsize, ysize, sizeof(T));
-    JXL_RETURN_IF_ERROR(plane.Allocate());
+    JXL_RETURN_IF_ERROR(plane.Allocate(memory_manager));
     return plane;
   }
 
@@ -227,12 +241,13 @@ class Image3 {
     return *this;
   }
 
-  static StatusOr<Image3> Create(const size_t xsize, const size_t ysize) {
-    StatusOr<PlaneT> plane0 = PlaneT::Create(xsize, ysize);
+  static StatusOr<Image3> Create(JxlMemoryManager* memory_manager,
+                                 const size_t xsize, const size_t ysize) {
+    StatusOr<PlaneT> plane0 = PlaneT::Create(memory_manager, xsize, ysize);
     JXL_RETURN_IF_ERROR(plane0.status());
-    StatusOr<PlaneT> plane1 = PlaneT::Create(xsize, ysize);
+    StatusOr<PlaneT> plane1 = PlaneT::Create(memory_manager, xsize, ysize);
     JXL_RETURN_IF_ERROR(plane1.status());
-    StatusOr<PlaneT> plane2 = PlaneT::Create(xsize, ysize);
+    StatusOr<PlaneT> plane2 = PlaneT::Create(memory_manager, xsize, ysize);
     JXL_RETURN_IF_ERROR(plane2.status());
     return Image3(std::move(plane0).value(), std::move(plane1).value(),
                   std::move(plane2).value());
@@ -283,6 +298,9 @@ class Image3 {
   }
 
   // Sizes of all three images are guaranteed to be equal.
+  JXL_INLINE JxlMemoryManager* memory_manager() const {
+    return planes_[0].memory_manager();
+  }
   JXL_INLINE size_t xsize() const { return planes_[0].xsize(); }
   JXL_INLINE size_t ysize() const { return planes_[0].ysize(); }
   // Returns offset [bytes] from one row to the next row of the same plane.

--- a/lib/extras/image_color_transform.cc
+++ b/lib/extras/image_color_transform.cc
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <utility>
 
+#include "lib/base/memory_manager.h"
 #include "lib/base/rect.h"
 #include "lib/base/status.h"
 #include "lib/cms/cms_interface.h"
@@ -26,8 +27,10 @@ Status ApplyColorTransform(const ColorEncoding& c_current,
   // Changing IsGray is probably a bug.
   JXL_CHECK(c_current.IsGray() == c_desired.IsGray());
   bool is_gray = c_current.IsGray();
+  JxlMemoryManager* memory_amanger = color.memory_manager();
   if (out->xsize() < rect.xsize() || out->ysize() < rect.ysize()) {
-    JXL_ASSIGN_OR_RETURN(*out, Image3F::Create(rect.xsize(), rect.ysize()));
+    JXL_ASSIGN_OR_RETURN(
+        *out, Image3F::Create(memory_amanger, rect.xsize(), rect.ysize()));
   } else {
     out->ShrinkTo(rect.xsize(), rect.ysize());
   }

--- a/lib/extras/image_ops.h
+++ b/lib/extras/image_ops.h
@@ -15,6 +15,7 @@
 #include <limits>
 
 #include "lib/base/compiler_specific.h"
+#include "lib/base/memory_manager.h"
 #include "lib/base/rect.h"
 #include "lib/base/status.h"
 #include "lib/extras/image.h"
@@ -118,7 +119,9 @@ StatusOr<Plane<T>> LinComb(const T lambda1, const Plane<T>& image1,
   const size_t ysize = image1.ysize();
   JXL_CHECK(xsize == image2.xsize());
   JXL_CHECK(ysize == image2.ysize());
-  JXL_ASSIGN_OR_RETURN(Plane<T> out, Plane<T>::Create(xsize, ysize));
+  JxlMemoryManager* memory_manager = image1.memory_manager();
+  JXL_ASSIGN_OR_RETURN(Plane<T> out,
+                       Plane<T>::Create(memory_manager, xsize, ysize));
   for (size_t y = 0; y < ysize; ++y) {
     const T* const JXL_RESTRICT row1 = image1.Row(y);
     const T* const JXL_RESTRICT row2 = image2.Row(y);

--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "lib/base/memory_manager.h"
 #include "lib/base/span.h"
 #include "lib/base/status.h"
 #include "lib/base/testing.h"
@@ -111,6 +112,7 @@ float BitsPerPixel(const PackedPixelFile& ppf,
 
 TEST(JpegliTest, JpegliSRGBDecodeTest) {
   TEST_LIBJPEG_SUPPORT();
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   std::string testimage = "jxl/flower/flower_small.rgb.depth8.ppm";
   PackedPixelFile ppf0;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf0));
@@ -125,11 +127,13 @@ TEST(JpegliTest, JpegliSRGBDecodeTest) {
   PackedPixelFile ppf2;
   JpegDecompressParams dparams;
   ASSERT_TRUE(DecodeJpeg(compressed, dparams, nullptr, &ppf2));
-  EXPECT_LT(ButteraugliDistance(ppf0, ppf2), ButteraugliDistance(ppf0, ppf1));
+  EXPECT_LT(ButteraugliDistance(memory_manager, ppf0, ppf2),
+            ButteraugliDistance(memory_manager, ppf0, ppf1));
 }
 
 TEST(JpegliTest, JpegliGrayscaleDecodeTest) {
   TEST_LIBJPEG_SUPPORT();
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   std::string testimage = "jxl/flower/flower_small.g.depth8.pgm";
   PackedPixelFile ppf0;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf0));
@@ -144,11 +148,13 @@ TEST(JpegliTest, JpegliGrayscaleDecodeTest) {
   PackedPixelFile ppf2;
   JpegDecompressParams dparams;
   ASSERT_TRUE(DecodeJpeg(compressed, dparams, nullptr, &ppf2));
-  EXPECT_LT(ButteraugliDistance(ppf0, ppf2), ButteraugliDistance(ppf0, ppf1));
+  EXPECT_LT(ButteraugliDistance(memory_manager, ppf0, ppf2),
+            ButteraugliDistance(memory_manager, ppf0, ppf1));
 }
 
 TEST(JpegliTest, JpegliXYBEncodeTest) {
   TEST_LIBJPEG_SUPPORT();
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   std::string testimage = "jxl/flower/flower_small.rgb.depth8.ppm";
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
@@ -163,11 +169,13 @@ TEST(JpegliTest, JpegliXYBEncodeTest) {
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
   EXPECT_SLIGHTLY_BELOW(BitsPerPixel(ppf_in, compressed), 1.45f);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(ppf_in, ppf_out), 1.32f);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(memory_manager, ppf_in, ppf_out),
+                        1.32f);
 }
 
 TEST(JpegliTest, JpegliDecodeTestLargeSmoothArea) {
   TEST_LIBJPEG_SUPPORT();
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   TestImage t;
   const size_t xsize = 2070;
   const size_t ysize = 1063;
@@ -193,11 +201,12 @@ TEST(JpegliTest, JpegliDecodeTestLargeSmoothArea) {
   PackedPixelFile ppf1;
   JpegDecompressParams dparams;
   ASSERT_TRUE(DecodeJpeg(compressed, dparams, nullptr, &ppf1));
-  EXPECT_LT(ButteraugliDistance(ppf0, ppf1), 3.0f);
+  EXPECT_LT(ButteraugliDistance(memory_manager, ppf0, ppf1), 3.0f);
 }
 
 TEST(JpegliTest, JpegliYUVEncodeTest) {
   TEST_LIBJPEG_SUPPORT();
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   std::string testimage = "jxl/flower/flower_small.rgb.depth8.ppm";
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
@@ -212,11 +221,13 @@ TEST(JpegliTest, JpegliYUVEncodeTest) {
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
   EXPECT_SLIGHTLY_BELOW(BitsPerPixel(ppf_in, compressed), 1.7f);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(ppf_in, ppf_out), 1.32f);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(memory_manager, ppf_in, ppf_out),
+                        1.32f);
 }
 
 TEST(JpegliTest, JpegliYUVChromaSubsamplingEncodeTest) {
   TEST_LIBJPEG_SUPPORT();
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   std::string testimage = "jxl/flower/flower_small.rgb.depth8.ppm";
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
@@ -233,12 +244,13 @@ TEST(JpegliTest, JpegliYUVChromaSubsamplingEncodeTest) {
     PackedPixelFile ppf_out;
     ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
     EXPECT_LE(BitsPerPixel(ppf_in, compressed), 1.55f);
-    EXPECT_LE(ButteraugliDistance(ppf_in, ppf_out), 1.82f);
+    EXPECT_LE(ButteraugliDistance(memory_manager, ppf_in, ppf_out), 1.82f);
   }
 }
 
 TEST(JpegliTest, JpegliYUVEncodeTestNoAq) {
   TEST_LIBJPEG_SUPPORT();
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   std::string testimage = "jxl/flower/flower_small.rgb.depth8.ppm";
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
@@ -254,10 +266,12 @@ TEST(JpegliTest, JpegliYUVEncodeTestNoAq) {
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
   EXPECT_SLIGHTLY_BELOW(BitsPerPixel(ppf_in, compressed), 1.85f);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(ppf_in, ppf_out), 1.25f);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(memory_manager, ppf_in, ppf_out),
+                        1.25f);
 }
 
 TEST(JpegliTest, JpegliHDRRoundtripTest) {
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   std::string testimage = "jxl/hdr_room.png";
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
@@ -274,7 +288,8 @@ TEST(JpegliTest, JpegliHDRRoundtripTest) {
   dparams.output_data_type = JXL_TYPE_UINT16;
   ASSERT_TRUE(DecodeJpeg(compressed, dparams, nullptr, &ppf_out));
   EXPECT_SLIGHTLY_BELOW(BitsPerPixel(ppf_in, compressed), 2.95f);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(ppf_in, ppf_out), 1.05f);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(memory_manager, ppf_in, ppf_out),
+                        1.05f);
 }
 
 TEST(JpegliTest, JpegliSetAppData) {
@@ -343,6 +358,7 @@ class JpegliColorQuantTestParam : public ::testing::TestWithParam<TestConfig> {
 
 TEST_P(JpegliColorQuantTestParam, JpegliColorQuantizeTest) {
   TEST_LIBJPEG_SUPPORT();
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   TestConfig config = GetParam();
   std::string testimage = "jxl/flower/flower_small.rgb.depth8.ppm";
   PackedPixelFile ppf0;
@@ -367,8 +383,8 @@ TEST_P(JpegliColorQuantTestParam, JpegliColorQuantizeTest) {
   dparams2.dither_mode = config.dither;
   ASSERT_TRUE(DecodeJpeg(compressed, dparams2, nullptr, &ppf2));
 
-  double dist1 = Butteraugli3Norm(ppf0, ppf1);
-  double dist2 = Butteraugli3Norm(ppf0, ppf2);
+  double dist1 = Butteraugli3Norm(memory_manager, ppf0, ppf1);
+  double dist2 = Butteraugli3Norm(memory_manager, ppf0, ppf2);
   printf("distance: %f  vs %f\n", dist2, dist1);
   if (config.passes == 1) {
     if (config.num_colors == 16 && config.dither == 2) {

--- a/lib/extras/metrics.h
+++ b/lib/extras/metrics.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 
 #include "lib/base/data_parallel.h"
+#include "lib/base/memory_manager.h"
 #include "lib/cms/cms_interface.h"
 #include "lib/extras/butteraugli.h"
 #include "lib/extras/image.h"
@@ -19,7 +20,8 @@ namespace jxl {
 
 // Computes the butteraugli distance and optionally the distmap of images in any
 // RGB color model, optionally with alpha channel.
-float ButteraugliDistance(const extras::PackedPixelFile& a,
+float ButteraugliDistance(JxlMemoryManager* memory_manager,
+                          const extras::PackedPixelFile& a,
                           const extras::PackedPixelFile& b,
                           ButteraugliParams params = ButteraugliParams(),
                           ImageF* distmap = nullptr, ThreadPool* pool = nullptr,
@@ -29,11 +31,13 @@ float ButteraugliDistance(const extras::PackedPixelFile& a,
 double ComputeDistanceP(const ImageF& distmap, const ButteraugliParams& params,
                         double p);
 
-float Butteraugli3Norm(const extras::PackedPixelFile& a,
+float Butteraugli3Norm(JxlMemoryManager* memory_manager,
+                       const extras::PackedPixelFile& a,
                        const extras::PackedPixelFile& b,
                        ThreadPool* pool = nullptr);
 
-double ComputePSNR(const extras::PackedPixelFile& a,
+double ComputePSNR(JxlMemoryManager* memory_manager,
+                   const extras::PackedPixelFile& a,
                    const extras::PackedPixelFile& b,
                    const JxlCmsInterface& cms);
 

--- a/lib/extras/packed_image.h
+++ b/lib/extras/packed_image.h
@@ -10,16 +10,14 @@
 // Helper class for storing external (int or float, interleaved) images. This is
 // the common format used by other libraries and in the libjxl API.
 
-#include <stddef.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <memory>
-#include <set>
 #include <string>
 #include <vector>
 

--- a/lib/extras/test_utils.cc
+++ b/lib/extras/test_utils.cc
@@ -51,5 +51,12 @@ std::vector<uint8_t> ReadTestData(const std::string& filename) {
   return data;
 }
 
+namespace {
+void* TestAlloc(void* /* opaque*/, size_t size) { return malloc(size); }
+void TestFree(void* /* opaque*/, void* address) { free(address); }
+JxlMemoryManager kMemoryManager{nullptr, &TestAlloc, &TestFree};
+}  // namespace
+JxlMemoryManager* MemoryManager() { return &kMemoryManager; };
+
 }  // namespace test
 }  // namespace jxl

--- a/lib/extras/test_utils.h
+++ b/lib/extras/test_utils.h
@@ -11,10 +11,14 @@
 #include <string>
 #include <vector>
 
+#include "lib/base/memory_manager.h"
+
 namespace jxl {
 namespace test {
 
 std::vector<uint8_t> ReadTestData(const std::string& filename);
+
+JxlMemoryManager* MemoryManager();
 
 }  // namespace test
 }  // namespace jxl

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,12 +12,13 @@ set(FUZZER_CORPUS_BINARIES)
 
 add_library(jxl_tool STATIC EXCLUDE_FROM_ALL
   cmdline.cc
+  no_memory_manager.cc
   speed_stats.cc
   tool_version.cc
 )
 target_compile_options(jxl_tool PUBLIC "${JPEGXL_INTERNAL_FLAGS}")
 target_include_directories(jxl_tool PUBLIC "${PROJECT_SOURCE_DIR}")
-target_link_libraries(jxl_tool PUBLIC hwy)
+target_link_libraries(jxl_tool PUBLIC jxl_base hwy)
 
 # The JPEGXL_VERSION is set from the builders.
 if(NOT DEFINED JPEGXL_VERSION OR JPEGXL_VERSION STREQUAL "")

--- a/tools/benchmark/benchmark_codec.cc
+++ b/tools/benchmark/benchmark_codec.cc
@@ -6,10 +6,9 @@
 
 #include "tools/benchmark/benchmark_codec.h"
 
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>

--- a/tools/benchmark/benchmark_codec.h
+++ b/tools/benchmark/benchmark_codec.h
@@ -7,9 +7,7 @@
 #ifndef TOOLS_BENCHMARK_BENCHMARK_CODEC_H_
 #define TOOLS_BENCHMARK_BENCHMARK_CODEC_H_
 
-#include <stdint.h>
-
-#include <deque>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -22,7 +20,6 @@
 #include "tools/args.h"
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_stats.h"
-#include "tools/cmdline.h"
 #include "tools/speed_stats.h"
 #include "tools/thread_pool_internal.h"
 

--- a/tools/no_memory_manager.cc
+++ b/tools/no_memory_manager.cc
@@ -1,0 +1,24 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "tools/no_memory_manager.h"
+
+#include <cstdlib>
+
+#include "lib/base/memory_manager.h"
+
+namespace jpegxl {
+namespace tools {
+
+namespace {
+void* ToolsAlloc(void* /* opaque*/, size_t size) { return malloc(size); }
+void ToolsFree(void* /* opaque*/, void* address) { free(address); }
+JxlMemoryManager kNoMemoryManager{nullptr, &ToolsAlloc, &ToolsFree};
+}  // namespace
+
+JxlMemoryManager* NoMemoryManager() { return &kNoMemoryManager; };
+
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/no_memory_manager.h
+++ b/tools/no_memory_manager.h
@@ -1,0 +1,19 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef TOOLS_NO_MEMORY_MANAGER_H_
+#define TOOLS_NO_MEMORY_MANAGER_H_
+
+#include "lib/base/memory_manager.h"
+
+namespace jpegxl {
+namespace tools {
+
+JxlMemoryManager* NoMemoryManager();
+
+}  // namespace tools
+}  // namespace jpegxl
+
+#endif  // TOOLS_NO_MEMORY_MANAGER_H_


### PR DESCRIPTION
Pointer to MemoryManager instance is conducted from API frontend to Plane. It is checked that instance is specified, when necessary, but memory is allocated as usual.

In next PR Memory manager will be used for actual memory allocation.

(cherry picked from commit 98c96657baeaf47035dd4e0edfa30dd6f1718997)
