### PR TITLE
Don't install gdk/gimp plugins

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -181,10 +181,8 @@ jobs:
           graphviz \
           imagemagick \
           libbrotli-dev \
-          libgdk-pixbuf2.0-dev \
           libgif-dev \
           libgtest-dev \
-          libgtk2.0-dev  \
           libjpeg-dev \
           libjpeg-turbo-progs \
           libopenexr-dev \

--- a/.github/workflows/build_test_cross.yml
+++ b/.github/workflows/build_test_cross.yml
@@ -129,10 +129,6 @@ jobs:
           # For OpenEXR:
           libilmbase-dev:${{ matrix.arch }}
           libopenexr-dev:${{ matrix.arch }}
-
-          # GTK plugins
-          libgdk-pixbuf2.0-dev:${{ matrix.arch }}
-          libgtk2.0-dev:${{ matrix.arch }}
         )
         if [[ "${{ matrix.build_target }}" != "x86_64-linux-gnu" ]]; then
           pkgs+=(

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,10 +81,8 @@ jobs:
             libbenchmark-dev \
             libbenchmark-tools \
             libbrotli-dev \
-            libgdk-pixbuf2.0-dev \
             libgif-dev \
             libgtest-dev \
-            libgtk2.0-dev  \
             libjpeg-dev \
             libjpeg-turbo-progs \
             libopenexr-dev \

--- a/.github/workflows/debug_ci.yml
+++ b/.github/workflows/debug_ci.yml
@@ -100,10 +100,6 @@ jobs:
           # For OpenEXR:
           libilmbase-dev:${{ matrix.arch }}
           libopenexr-dev:${{ matrix.arch }}
-
-          # GTK plugins
-          libgdk-pixbuf2.0-dev:${{ matrix.arch }}
-          libgtk2.0-dev:${{ matrix.arch }}
         )
         if [[ "${{ matrix.build_target }}" != "x86_64-linux-gnu" ]]; then
           pkgs+=(

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,10 +57,8 @@ jobs:
           doxygen \
           graphviz \
           libbrotli-dev \
-          libgdk-pixbuf2.0-dev \
           libgif-dev \
           libgtest-dev \
-          libgtk2.0-dev  \
           libjpeg-dev \
           libopenexr-dev \
           libpng-dev \
@@ -127,10 +125,8 @@ jobs:
         - ubuntu:20.04
         - debian:bullseye
         - debian:bookworm
-        # GIMP-2 package is removed: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1078402
-        # GIMP-3 package has incompatible API: https://github.com/libjxl/libjxl/issues/4037
-        # - debian:trixie
-        # - debian:sid
+        - debian:trixie
+        - debian:sid
 
     container:
       image: ${{ matrix.os }}

--- a/debian/control
+++ b/debian/control
@@ -8,9 +8,7 @@ Build-Depends:
  cmake,
  debhelper (>= 9),
  libbrotli-dev,
- libgdk-pixbuf-2.0-dev | libgdk-pixbuf2.0-dev,
  libgif-dev,
- libgimp2.0-dev,
  libgoogle-perftools-dev,
  libgtest-dev,
  libhwy-dev (>= 1.0.0),
@@ -65,23 +63,3 @@ Description: JPEG XL Image Coding System - "JXL" (shared libraries)
  several features that help transition from the legacy JPEG format.
  .
  This package installs shared libraries.
-
-Package: libjxl-gdk-pixbuf
-Architecture: any
-Multi-Arch: same
-Section: libs
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Pre-Depends: ${misc:Pre-Depends}
-Description: JPEG XL Plugin for gdk-pixbuf
- This package installs the required files for reading JPEG XL files in
- GTK applications.
-
-Package: libjxl-gimp-plugin
-Architecture: any
-Multi-Arch: same
-Section: graphics
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Pre-Depends: ${misc:Pre-Depends}
-Enhances: gimp
-Description: JPEG XL Import and Export Plugin for GIMP
- This is a plugin for GIMP version 2.10.x to import and export JPEG XL images.

--- a/debian/libjxl-gdk-pixbuf.install
+++ b/debian/libjxl-gdk-pixbuf.install
@@ -1,3 +1,0 @@
-usr/lib/*/gdk-pixbuf-*/*/loaders/*
-usr/share/mime/packages/image-jxl.xml
-usr/share/thumbnailers/jxl.thumbnailer

--- a/debian/libjxl-gimp-plugin.install
+++ b/debian/libjxl-gimp-plugin.install
@@ -1,1 +1,0 @@
-usr/lib/gimp

--- a/doc/debugging_workflows.md
+++ b/doc/debugging_workflows.md
@@ -49,11 +49,10 @@ apt update
 
 apt-get install -y \
   clang-14 cmake doxygen g++-aarch64-linux-gnu graphviz libbrotli-dev:${ARCH} \
-  libc6-dev-${ARCH}-cross libgdk-pixbuf2.0-dev:${ARCH} libgif-dev:${ARCH} \
-  libgtk2.0-dev:${ARCH} libilmbase-dev:${ARCH} libjpeg-dev:${ARCH} \
-  libopenexr-dev:${ARCH} libpng-dev:${ARCH} libstdc++-12-dev-${ARCH}-cross \
-  libstdc++-12-dev:${ARCH} libwebp-dev:${ARCH} ninja-build pkg-config \
-  qemu-user-static unzip xdg-utils xvfb
+  libc6-dev-${ARCH}-cross libgif-dev:${ARCH} libilmbase-dev:${ARCH} \
+  libjpeg-dev:${ARCH} libopenexr-dev:${ARCH} libpng-dev:${ARCH} \
+  libstdc++-12-dev-${ARCH}-cross libstdc++-12-dev:${ARCH} libwebp-dev:${ARCH} \
+  ninja-build pkg-config qemu-user-static unzip xdg-utils xvfb
 
 #apt-get install -y binutils-${BUILD_TARGET} gcc-${BUILD_TARGET}
 #apt-get install -y \


### PR DESCRIPTION
(because there are none)

Likely fixes release pipelines
