### PR TITLE
Allow jpegli quant tables to be used for JSC_GRAYSCALE images

### DIFF
--- a/lib/jpegli/quant.cc
+++ b/lib/jpegli/quant.cc
@@ -648,7 +648,7 @@ void SetQuantMatrices(j_compress_ptr cinfo, float distances[NUM_QUANT_TBLS],
     base_quant_matrix[0] = kBaseQuantMatrixXYB;
     base_quant_matrix[1] = kBaseQuantMatrixXYB + DCTSIZE2;
     base_quant_matrix[2] = kBaseQuantMatrixXYB + 2 * DCTSIZE2;
-  } else if (cinfo->jpeg_color_space == JCS_YCbCr && !m->use_std_tables) {
+  } else if ((cinfo->jpeg_color_space == JCS_YCbCr || cinfo->jpeg_color_space == JCS_GRAYSCALE ) && !m->use_std_tables) {
     global_scale = kGlobalScaleYCbCr;
     if (m->cicp_transfer_function == kTransferFunctionPQ) {
       global_scale *= .4f;


### PR DESCRIPTION
This fixes a bug (unless it's intentional) that limits grayscale images to only use the standard quantization tables defined in the appendix of the JPEG standard

<!-- Thank you for considering a contribution to `jpegli`! -->

### Description

Jpegli is able to deliver significantly better compression rates over other codecs, like libjpeg_turbo, thanks both to it's adaptive quantization approach, but also because of the optimized quantization tables it uses.
This can be observed by using the "--std_quant" option with `cjpegli` which forces the encoder to fall back to the tables defined in the appendix of the JPEG standard. With that quantization table, you can only achieve a file size vs quality ratio that's similar to libjpeg_turbo, at least when evaluated using only PSNR as the loss function.

After getting worse than expected compression rates for some grayscale images, I poked around in the jpegli code base and found that the optimized quantization tables are only enabled if the color space is YCbCr.
Perhaps this was intended to be a check to exclude files using XYB? Grayscale is pretty rare so it's possible this was just overlooked.

My testing shows improvements in compression rate while maintaining quality, with this fix.
Tested using open source build instructions for cjpegli on a corpus of grayscale PNGs.

### Pull Request Checklist

- [ ] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/google/jpegli/blob/main/CONTRIBUTING.md) for more details.
