### PR TITLE
[RFC] Add API for setting adaptive quantization parameters

### DIFF
--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -145,6 +145,17 @@ void jpegli_set_input_format(j_compress_ptr cinfo, JpegliDataType data_type,
 // Enabled by default.
 void jpegli_enable_adaptive_quantization(j_compress_ptr cinfo, boolean value);
 
+// Sets the adaptive quantization settings, allowing for control of the
+// conditions for when coefficients are zero'd out. Each of the mul and
+// offset parameters consists of an array of 64 values, one for each
+// coefficient.
+// Note that when used, this function must be called once for each
+// component of the image.
+void jpegli_set_adaptive_quantization_settings(j_compress_ptr cinfo,
+                                               int which_component,
+                                               const float* mul,
+                                               const float offset);
+
 // Sets the default progression parameters, where level 0 is sequential, and
 // greater level value means more progression steps. Default is 2.
 void jpegli_set_progressive_level(j_compress_ptr cinfo, int level);

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -90,6 +90,7 @@ struct jpeg_comp_master {
   float* quant_mul[jpegli::kMaxComponents];
   float* zero_bias_offset[jpegli::kMaxComponents];
   float* zero_bias_mul[jpegli::kMaxComponents];
+  bool zero_bias_params_set;
   int h_factor[jpegli::kMaxComponents];
   int v_factor[jpegli::kMaxComponents];
   // Array of Huffman tables that will be encoded in one or more DHT segments.

--- a/lib/jpegli/quant.cc
+++ b/lib/jpegli/quant.cc
@@ -732,7 +732,7 @@ void InitQuantizer(j_compress_ptr cinfo, QuantPass pass) {
       }
     }
   }
-  if (m->use_adaptive_quantization) {
+  if (m->use_adaptive_quantization && !m->zero_bias_params_set) {
     for (int c = 0; c < cinfo->num_components; ++c) {
       for (int k = 0; k < DCTSIZE2; ++k) {
         m->zero_bias_mul[c][k] = k == 0 ? 0.0f : 0.5f;


### PR DESCRIPTION
This allows for setting the adaptive quantization bias multiplier and offset parameters . Together with using custom base quantization tables, this allows you to tune jpegli to deliver better compression rates for specific datasets or metrics.

### Description

I added "RFC" to the title since I'm not sure what's the best approach for adding test coverage.
I could add support to cjpegli but it's quite a niche use case so I'm not sure this is the best place for it, otherwise a unit test may be more suitable.

The change has been tested using a separate command line tool that includes jpegli, however all that testing was done on grayscale images.


### Pull Request Checklist

- [ ] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/google/jpegli/blob/main/CONTRIBUTING.md) for more details.
