### PR TITLE
Build only lib on Windows #27

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,3 +21,4 @@ Sami Boukortt
 Sebastian Gomez-Gonzalez
 Thomas Fischbacher
 Zoltan Szabadka
+Ede Bittner

--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -106,7 +106,7 @@ endif()
 # Build libjpeg.so that links to libjpeg-static
 #
 
-if (JPEGXL_ENABLE_JPEGLI_LIBJPEG AND NOT APPLE AND NOT WIN32 AND NOT EMSCRIPTEN)
+if (JPEGXL_ENABLE_JPEGLI_LIBJPEG AND NOT APPLE AND NOT EMSCRIPTEN)
 add_library(jpegli-libjpeg-obj OBJECT "${JPEGXL_INTERNAL_JPEGLI_WRAPPER_SOURCES}")
 target_compile_options(jpegli-libjpeg-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
 target_compile_options(jpegli-libjpeg-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
@@ -133,7 +133,8 @@ set_target_properties(jpeg PROPERTIES
 # Add a jpeg.version file as a version script to tag symbols with the
 # appropriate version number.
 set_target_properties(jpeg PROPERTIES
-  LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version.${JPEGLI_LIBJPEG_LIBRARY_SOVERSION})
+  LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version.${JPEGLI_LIBJPEG_LIBRARY_SOVERSION}
+  WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set_property(TARGET jpeg APPEND_STRING PROPERTY
   LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version.${JPEGLI_LIBJPEG_LIBRARY_SOVERSION}")
 


### PR DESCRIPTION
Jpeg.dll wasn't build on Windows platform.
 - enable WIN32 jpeg dll build
 - exporting all symbols from the jpeg.dll (because no export were defined)


### Description

Jpeg.dll wasn't build on Windows platform. I've added the minimal changeset to make it work under windows.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file? added to Contributors
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/google/jpegli/blob/main/CONTRIBUTING.md) for more details.
