### PR TITLE
Add jpegli-static-obj OBJECT build target

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Gerhard Huber <support@pl32.com>
 Galaxy4594 <164440799+Galaxy4594@users.noreply.github.com>
 gi-man
 Gilles Devillers (GilDev) <gildev@gmail.com>
+Go Kudo <g-kudo@colopl.co.jp>
 Heiko Becker <heirecka@exherbo.org>
 Ivan Kokorev
 Jim Robinson <jimbo2150@gmail.com>

--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -31,18 +31,16 @@ configure_file(
 configure_file(
   ../third_party/libjpeg-turbo/jmorecfg.h include/jpegli/jmorecfg.h COPYONLY)
 
-add_library(jpegli-static STATIC EXCLUDE_FROM_ALL "${JPEGXL_INTERNAL_JPEGLI_SOURCES}")
-target_compile_options(jpegli-static PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
-target_compile_options(jpegli-static PUBLIC ${JPEGXL_COVERAGE_FLAGS})
-set_property(TARGET jpegli-static PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(jpegli-static PRIVATE
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
-  "${JXL_HWY_INCLUDE_DIRS}"
-)
-target_include_directories(jpegli-static PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/jpegli>"
-)
-target_link_libraries(jpegli-static PUBLIC ${JPEGLI_INTERNAL_LIBS})
+add_library(jpegli-static-obj OBJECT "${JPEGXL_INTERNAL_JPEGLI_SOURCES}")
+set_property(TARGET jpegli-static-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_options(jpegli-static-obj PUBLIC "${JPEGXL_INTERNAL_FLAGS}")
+target_include_directories(jpegli-static-obj
+  PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>" "${JXL_HWY_INCLUDE_DIRS}"
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/jpegli>")
+target_link_libraries(jpegli-static-obj PUBLIC ${JPEGLI_INTERNAL_LIBS})
+
+add_library(jpegli-static STATIC EXCLUDE_FROM_ALL $<TARGET_OBJECTS:jpegli-static-obj>)
+target_link_libraries(jpegli-static PUBLIC jpegli-static-obj)
 
 #
 # Tests for jpegli-static


### PR DESCRIPTION
### Description

Adds an intermediate object target `jpegli-static-obj` for building the `jpegli-static` library.

This makes it easier to extract object files in external projects, allowing the building of completely static binaries.
Combined with the changes in PR #115, this will enable the creation of libraries using jpegli for platforms that require strict static linking, such as iOS applications.

```cmake
add_library(${CMAKE_PROJECT_NAME} STATIC
    ${SOURCES}
    $<TARGET_OBJECTS:jpegli-static-obj>
    $<TARGET_OBJECTS:jpegli-libjpeg-obj>
    $<TARGET_OBJECTS:hwy>
)
target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
    ${jpegli_BINARY_DIR}/lib/include/jpegli
    ${INCLUDE_DIRS}
)
```

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
