### PR TITLE
APP14 Marker, Better Subsampling and High Quality Improvements

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -439,10 +439,10 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     // All factors need to be specified to subsample the blue channel
     // for XYB. H and V are swapped between YCbCr and XYB.
     if (!jpeg_settings.chroma_subsampling.empty()) {
-//	  cinfo.master->chroma_subsampling_set_by_cli = true;
+    cinfo.master->chroma_subsampling_set_by_cli = true;
       if (jpeg_settings.chroma_subsampling == "444") {
         cinfo.comp_info[0].h_samp_factor = 1;
-		cinfo.comp_info[0].v_samp_factor = 1;
+	cinfo.comp_info[0].v_samp_factor = 1;
       } else if (jpeg_settings.chroma_subsampling == "440") {
         cinfo.comp_info[0].h_samp_factor = 1;
         cinfo.comp_info[0].v_samp_factor = 2;

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -474,7 +474,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
 	}
       } else if (jpeg_settings.chroma_subsampling == "420") {
         cinfo.comp_info[0].h_samp_factor = 2;
-	cinfo.comp_info[0].h_samp_factor = 2;
+	cinfo.comp_info[0].v_samp_factor = 2;
 	if (cinfo->master->xyb_mode) {
 	// Subsample blue channel for XYB.
 	cinfo.comp_info[0].h_samp_factor = 2;

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -435,23 +435,60 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     jpegli_set_cicp_transfer_function(&cinfo, cicp_tf);
     jpegli_set_defaults(&cinfo);
     float distance = jpegli_quality_to_distance(jpeg_settings.quality);
+    // TODO(Jonnyawsom3): Clean up redundant variables later.
+    // Ideally use YBX instead of XYB, and try subsampling X too
+    // to avoid any of this. Subsampling doesn't help XYB much anyway
+    // but forcing it shouldn't ruin quality, hence spaghetti.
     if (!jpeg_settings.chroma_subsampling.empty()) {
       if (jpeg_settings.chroma_subsampling == "444") {
+	// Set all in case of 444 XYB
         cinfo.comp_info[0].h_samp_factor = 1;
-        cinfo.comp_info[0].v_samp_factor = 1;
+	cinfo.comp_info[0].v_samp_factor = 1;
+	cinfo.comp_info[1].h_samp_factor = 1;
+	cinfo.comp_info[1].v_samp_factor = 1;
+	cinfo.comp_info[2].h_samp_factor = 1;
+	cinfo.comp_info[2].v_samp_factor = 1;
       } else if (jpeg_settings.chroma_subsampling == "440") {
         cinfo.comp_info[0].h_samp_factor = 1;
         cinfo.comp_info[0].v_samp_factor = 2;
+	if (cinfo->master->xyb_mode) {
+	// Subsample blue channel for XYB.
+	cinfo.comp_info[0].h_samp_factor = 1;
+	cinfo.comp_info[0].v_samp_factor = 2;
+	cinfo.comp_info[1].h_samp_factor = 1;
+	cinfo.comp_info[1].v_samp_factor = 2;
+	cinfo.comp_info[2].h_samp_factor = 1;
+	cinfo.comp_info[2].v_samp_factor = 1;
+	}
       } else if (jpeg_settings.chroma_subsampling == "422") {
         cinfo.comp_info[0].h_samp_factor = 2;
         cinfo.comp_info[0].v_samp_factor = 1;
+	if (cinfo->master->xyb_mode) {
+	// Subsample blue channel for XYB.
+	cinfo.comp_info[0].h_samp_factor = 2;
+	cinfo.comp_info[0].v_samp_factor = 1;
+	cinfo.comp_info[1].h_samp_factor = 2;
+	cinfo.comp_info[1].v_samp_factor = 1;
+	cinfo.comp_info[2].h_samp_factor = 1;
+	cinfo.comp_info[2].v_samp_factor = 1;
+	}
       } else if (jpeg_settings.chroma_subsampling == "420") {
         cinfo.comp_info[0].h_samp_factor = 2;
-        cinfo.comp_info[0].v_samp_factor = 2;
+	cinfo.comp_info[0].h_samp_factor = 2;
+	if (cinfo->master->xyb_mode) {
+	// Subsample blue channel for XYB.
+	cinfo.comp_info[0].h_samp_factor = 2;
+	cinfo.comp_info[0].v_samp_factor = 2;
+	cinfo.comp_info[1].h_samp_factor = 2;
+	cinfo.comp_info[1].v_samp_factor = 2;
+	cinfo.comp_info[2].h_samp_factor = 1;
+	cinfo.comp_info[2].v_samp_factor = 1;
+	}
       } else {
         return false;
       }
-      for (int i = 1; i < cinfo.num_components; ++i) {
+      if (!cinfo->master->xyb_mode) {
+	for (int i = 1; i < cinfo.num_components; ++i) {
         cinfo.comp_info[i].h_samp_factor = 1;
         cinfo.comp_info[i].v_samp_factor = 1;
       }

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -435,11 +435,10 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     jpegli_set_cicp_transfer_function(&cinfo, cicp_tf);
     jpegli_set_defaults(&cinfo);
     float distance = jpegli_quality_to_distance(jpeg_settings.quality);
-    // TODO(Jonnyawsom3): Clean up redundant variables later.
-    // Figure out why H and V are swapped in some cases.
+    // All factors need to be specified to subsample the blue channel
+    // for XYB. H and V are swapped between YCbCr and XYB.
     if (!jpeg_settings.chroma_subsampling.empty()) {
       if (jpeg_settings.chroma_subsampling == "444") {
-	// Set all in case of 444 XYB
         cinfo.comp_info[0].h_samp_factor = 1;
 	cinfo.comp_info[0].v_samp_factor = 1;
 	cinfo.comp_info[1].h_samp_factor = 1;
@@ -450,7 +449,6 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         cinfo.comp_info[0].h_samp_factor = 1;
         cinfo.comp_info[0].v_samp_factor = 2;
 	if (jpeg_settings.xyb) {
-	// Subsample blue channel for XYB.
 	cinfo.comp_info[0].h_samp_factor = 2;
 	cinfo.comp_info[0].v_samp_factor = 1;
 	cinfo.comp_info[1].h_samp_factor = 2;
@@ -462,7 +460,6 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         cinfo.comp_info[0].h_samp_factor = 2;
         cinfo.comp_info[0].v_samp_factor = 1;
 	if (jpeg_settings.xyb) {
-	// Subsample blue channel for XYB.
 	cinfo.comp_info[0].h_samp_factor = 2;
 	cinfo.comp_info[0].v_samp_factor = 2;
 	cinfo.comp_info[1].h_samp_factor = 2;
@@ -474,7 +471,6 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         cinfo.comp_info[0].h_samp_factor = 2;
 	cinfo.comp_info[0].v_samp_factor = 2;
 	if (jpeg_settings.xyb) {
-	// Subsample blue channel for XYB.
 	cinfo.comp_info[0].h_samp_factor = 2;
 	cinfo.comp_info[0].v_samp_factor = 2;
 	cinfo.comp_info[1].h_samp_factor = 2;
@@ -489,14 +485,15 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
 	for (int i = 1; i < cinfo.num_components; ++i) {
         cinfo.comp_info[i].h_samp_factor = 1;
         cinfo.comp_info[i].v_samp_factor = 1;
+	}
       }
-    } else if ((jpeg_settings.distance >= 6.4 && !jpeg_settings.xyb) ||
+    } else if ((jpeg_settings.distance >= 6.4 && colorspace == JCS_YCbCr) ||
 	       (jpeg_settings.quality > 0.0 && distance >= 6.4)) {
-        // At lower qualities 420 subsampling begins to outperform 444
+        // At low quality, 420 subsampling begins to outperform 444.
         cinfo.comp_info[0].h_samp_factor = 2;
         cinfo.comp_info[0].v_samp_factor = 2;
       } else {
-	// Default to 444 for XYB or medium to high quality
+	// Default to 444 for RGB(XYB) JPEG or medium to high quality.
         cinfo.comp_info[0].h_samp_factor = 1;
         cinfo.comp_info[0].v_samp_factor = 1;
       }

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -434,17 +434,13 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     }
     jpegli_set_cicp_transfer_function(&cinfo, cicp_tf);
     jpegli_set_defaults(&cinfo);
-    float qDistance = jpegli_quality_to_distance(jpeg_settings.quality);
+    // Defaults are set in lib/jpegli/encode.cc#L799
     // All factors need to be specified to subsample the blue channel
     // for XYB. H and V are swapped between YCbCr and XYB.
     if (!jpeg_settings.chroma_subsampling.empty()) {
       if (jpeg_settings.chroma_subsampling == "444") {
         cinfo.comp_info[0].h_samp_factor = 1;
 	cinfo.comp_info[0].v_samp_factor = 1;
-	cinfo.comp_info[1].h_samp_factor = 1;
-	cinfo.comp_info[1].v_samp_factor = 1;
-	cinfo.comp_info[2].h_samp_factor = 1;
-	cinfo.comp_info[2].v_samp_factor = 1;
       } else if (jpeg_settings.chroma_subsampling == "440") {
         cinfo.comp_info[0].h_samp_factor = 1;
         cinfo.comp_info[0].v_samp_factor = 2;
@@ -481,22 +477,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       } else {
         return false;
       }
-      if (!jpeg_settings.xyb) {
-	for (int i = 1; i < cinfo.num_components; ++i) {
-        cinfo.comp_info[i].h_samp_factor = 1;
-        cinfo.comp_info[i].v_samp_factor = 1;
-	}
-      }
-    } else if ((jpeg_settings.distance >= 6.4 && colorspace == JCS_YCbCr) ||
-	       (jpeg_settings.quality > 0.0 && qDistance >= 6.4)) {
-        // At low quality, 420 subsampling begins to outperform 444.
-        cinfo.comp_info[0].h_samp_factor = 2;
-        cinfo.comp_info[0].v_samp_factor = 2;
-      } else {
-	// Default to 444 for RGB(XYB) JPEG or medium to high quality.
-        cinfo.comp_info[0].h_samp_factor = 1;
-        cinfo.comp_info[0].v_samp_factor = 1;
-      }
+    }
     jpegli_enable_adaptive_quantization(
         &cinfo, TO_JXL_BOOL(jpeg_settings.use_adaptive_quantization));
     if (jpeg_settings.psnr_target > 0.0) {

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -434,6 +434,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     }
     jpegli_set_cicp_transfer_function(&cinfo, cicp_tf);
     jpegli_set_defaults(&cinfo);
+    float distance = jpegli_quality_to_distance(jpeg_settings.quality);
     if (!jpeg_settings.chroma_subsampling.empty()) {
       if (jpeg_settings.chroma_subsampling == "444") {
         cinfo.comp_info[0].h_samp_factor = 1;
@@ -454,11 +455,15 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         cinfo.comp_info[i].h_samp_factor = 1;
         cinfo.comp_info[i].v_samp_factor = 1;
       }
-    } else if (!jpeg_settings.xyb) {
-      // Default is no chroma subsampling.
-      cinfo.comp_info[0].h_samp_factor = 1;
-      cinfo.comp_info[0].v_samp_factor = 1;
-    }
+    } if ((jpeg_settings.distance >= 6.4 && !jpeg_settings.xyb) || 
+	      (jpeg_settings.quality > 0.0 && jpegli_quality_to_distance(jpeg_settings.quality) >= 6.4)) {
+        // At lower qualities 420 subsampling begins to outperform 444
+        cinfo.comp_info[0].h_samp_factor = 2;
+        cinfo.comp_info[0].v_samp_factor = 2;
+      } else {
+        cinfo.comp_info[0].h_samp_factor = 1;
+        cinfo.comp_info[0].v_samp_factor = 1;
+      }
     jpegli_enable_adaptive_quantization(
         &cinfo, TO_JXL_BOOL(jpeg_settings.use_adaptive_quantization));
     if (jpeg_settings.psnr_target > 0.0) {

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -455,12 +455,12 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         cinfo.comp_info[i].h_samp_factor = 1;
         cinfo.comp_info[i].v_samp_factor = 1;
       }
-    } if ((jpeg_settings.distance >= 6.4 && !jpeg_settings.xyb) || 
-	      (jpeg_settings.quality > 0.0 && jpegli_quality_to_distance(jpeg_settings.quality) >= 6.4)) {
+    } else if ((jpeg_settings.distance >= 6.4 && !jpeg_settings.xyb) {
         // At lower qualities 420 subsampling begins to outperform 444
         cinfo.comp_info[0].h_samp_factor = 2;
         cinfo.comp_info[0].v_samp_factor = 2;
       } else {
+	// Default to 444 for XYB or medium to high quality
         cinfo.comp_info[0].h_samp_factor = 1;
         cinfo.comp_info[0].v_samp_factor = 1;
       }

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -434,7 +434,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     }
     jpegli_set_cicp_transfer_function(&cinfo, cicp_tf);
     jpegli_set_defaults(&cinfo);
-    float distance = jpegli_quality_to_distance(jpeg_settings.quality);
+    float qDistance = jpegli_quality_to_distance(jpeg_settings.quality);
     // All factors need to be specified to subsample the blue channel
     // for XYB. H and V are swapped between YCbCr and XYB.
     if (!jpeg_settings.chroma_subsampling.empty()) {
@@ -450,7 +450,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         cinfo.comp_info[0].v_samp_factor = 2;
 	if (jpeg_settings.xyb) {
 	cinfo.comp_info[0].h_samp_factor = 2;
-	cinfo.comp_info[0].v_samp_factor = 1;
+	cinfo.comp_info[0].v_samp_factor = 2;
 	cinfo.comp_info[1].h_samp_factor = 2;
 	cinfo.comp_info[1].v_samp_factor = 2;
 	cinfo.comp_info[2].h_samp_factor = 2;
@@ -488,7 +488,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
 	}
       }
     } else if ((jpeg_settings.distance >= 6.4 && colorspace == JCS_YCbCr) ||
-	       (jpeg_settings.quality > 0.0 && distance >= 6.4)) {
+	       (jpeg_settings.quality > 0.0 && qDistance >= 6.4)) {
         // At low quality, 420 subsampling begins to outperform 444.
         cinfo.comp_info[0].h_samp_factor = 2;
         cinfo.comp_info[0].v_samp_factor = 2;

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -436,9 +436,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     jpegli_set_defaults(&cinfo);
     float distance = jpegli_quality_to_distance(jpeg_settings.quality);
     // TODO(Jonnyawsom3): Clean up redundant variables later.
-    // Ideally use YBX instead of XYB, and try subsampling X too
-    // to avoid any of this. Subsampling doesn't help XYB much anyway
-    // but forcing it shouldn't ruin quality, hence spaghetti.
+    // Figure out why H and V are swapped in some cases.
     if (!jpeg_settings.chroma_subsampling.empty()) {
       if (jpeg_settings.chroma_subsampling == "444") {
 	// Set all in case of 444 XYB

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -453,11 +453,11 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         cinfo.comp_info[0].v_samp_factor = 2;
 	if (jpeg_settings.xyb) {
 	// Subsample blue channel for XYB.
-	cinfo.comp_info[0].h_samp_factor = 1;
-	cinfo.comp_info[0].v_samp_factor = 2;
-	cinfo.comp_info[1].h_samp_factor = 1;
+	cinfo.comp_info[0].h_samp_factor = 2;
+	cinfo.comp_info[0].v_samp_factor = 1;
+	cinfo.comp_info[1].h_samp_factor = 2;
 	cinfo.comp_info[1].v_samp_factor = 2;
-	cinfo.comp_info[2].h_samp_factor = 1;
+	cinfo.comp_info[2].h_samp_factor = 2;
 	cinfo.comp_info[2].v_samp_factor = 1;
 	}
       } else if (jpeg_settings.chroma_subsampling == "422") {
@@ -466,11 +466,11 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
 	if (jpeg_settings.xyb) {
 	// Subsample blue channel for XYB.
 	cinfo.comp_info[0].h_samp_factor = 2;
-	cinfo.comp_info[0].v_samp_factor = 1;
+	cinfo.comp_info[0].v_samp_factor = 2;
 	cinfo.comp_info[1].h_samp_factor = 2;
-	cinfo.comp_info[1].v_samp_factor = 1;
+	cinfo.comp_info[1].v_samp_factor = 2;
 	cinfo.comp_info[2].h_samp_factor = 1;
-	cinfo.comp_info[2].v_samp_factor = 1;
+	cinfo.comp_info[2].v_samp_factor = 2;
 	}
       } else if (jpeg_settings.chroma_subsampling == "420") {
         cinfo.comp_info[0].h_samp_factor = 2;

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -34,6 +34,7 @@
 #include "lib/extras/xyb_transform.h"
 #include "lib/jpegli/common.h"
 #include "lib/jpegli/encode.h"
+#include "lib/jpegli/encode_internal.h"
 #include "lib/jpegli/types.h"
 
 namespace jxl {
@@ -438,9 +439,10 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     // All factors need to be specified to subsample the blue channel
     // for XYB. H and V are swapped between YCbCr and XYB.
     if (!jpeg_settings.chroma_subsampling.empty()) {
+//	  cinfo.master->chroma_subsampling_set_by_cli = true;
       if (jpeg_settings.chroma_subsampling == "444") {
         cinfo.comp_info[0].h_samp_factor = 1;
-	cinfo.comp_info[0].v_samp_factor = 1;
+		cinfo.comp_info[0].v_samp_factor = 1;
       } else if (jpeg_settings.chroma_subsampling == "440") {
         cinfo.comp_info[0].h_samp_factor = 1;
         cinfo.comp_info[0].v_samp_factor = 2;

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -451,7 +451,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       } else if (jpeg_settings.chroma_subsampling == "440") {
         cinfo.comp_info[0].h_samp_factor = 1;
         cinfo.comp_info[0].v_samp_factor = 2;
-	if (cinfo->master->xyb_mode) {
+	if (jpeg_settings.xyb) {
 	// Subsample blue channel for XYB.
 	cinfo.comp_info[0].h_samp_factor = 1;
 	cinfo.comp_info[0].v_samp_factor = 2;
@@ -463,7 +463,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       } else if (jpeg_settings.chroma_subsampling == "422") {
         cinfo.comp_info[0].h_samp_factor = 2;
         cinfo.comp_info[0].v_samp_factor = 1;
-	if (cinfo->master->xyb_mode) {
+	if (jpeg_settings.xyb) {
 	// Subsample blue channel for XYB.
 	cinfo.comp_info[0].h_samp_factor = 2;
 	cinfo.comp_info[0].v_samp_factor = 1;
@@ -475,7 +475,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       } else if (jpeg_settings.chroma_subsampling == "420") {
         cinfo.comp_info[0].h_samp_factor = 2;
 	cinfo.comp_info[0].v_samp_factor = 2;
-	if (cinfo->master->xyb_mode) {
+	if (jpeg_settings.xyb) {
 	// Subsample blue channel for XYB.
 	cinfo.comp_info[0].h_samp_factor = 2;
 	cinfo.comp_info[0].v_samp_factor = 2;
@@ -487,12 +487,13 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       } else {
         return false;
       }
-      if (!cinfo->master->xyb_mode) {
+      if (!jpeg_settings.xyb) {
 	for (int i = 1; i < cinfo.num_components; ++i) {
         cinfo.comp_info[i].h_samp_factor = 1;
         cinfo.comp_info[i].v_samp_factor = 1;
       }
-    } else if ((jpeg_settings.distance >= 6.4 && !jpeg_settings.xyb) {
+    } else if ((jpeg_settings.distance >= 6.4 && !jpeg_settings.xyb) ||
+	       (jpeg_settings.quality > 0.0 && distance >= 6.4)) {
         // At lower qualities 420 subsampling begins to outperform 444
         cinfo.comp_info[0].h_samp_factor = 2;
         cinfo.comp_info[0].v_samp_factor = 2;

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -833,8 +833,11 @@ void jpegli_set_distance(j_compress_ptr cinfo, float distance,
   if (distance >= 1.9f && !(cinfo->master->xyb_mode) &&
     !cinfo->master->chroma_subsampling_set_by_cli) {
     // At medium qualities, 420 subsampling begins to outperform 444.
-    cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
+	cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
+    if (cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_CMYK) {
+    cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
     }
+  }
   // Disable adaptive quantization at high qualities.
   if (distance <= 1.0f) {
       cinfo->master->use_adaptive_quantization = false;
@@ -871,8 +874,11 @@ void jpegli_set_quality(j_compress_ptr cinfo, int quality,
   if (distance >= 1.9f && !(cinfo->master->xyb_mode) &&
     !cinfo->master->chroma_subsampling_set_by_cli) {
     // At medium qualities, 420 subsampling begins to outperform 444.
-    cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
+	cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
+    if (cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_CMYK) {
+    cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
     }
+  }
   // Disable adaptive quantization at high qualities.
   if (distance <= 1.0f) {
       cinfo->master->use_adaptive_quantization = false;

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -801,16 +801,12 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     comp->dc_tbl_no = 0;
     comp->ac_tbl_no = 0;
   }
+  // Subsampling is handled in lib/extras/enc/jpegli.cc#L438
   if (colorspace == JCS_RGB) {
     cinfo->comp_info[0].component_id = 'R';
     cinfo->comp_info[1].component_id = 'G';
     cinfo->comp_info[2].component_id = 'B';
     if (cinfo->master->xyb_mode) {
-      // Subsampling RGB JPEG is incompatible with JPEG XL transcoding.
-      // Subsample blue channel.
-      //cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
-      //cinfo->comp_info[1].h_samp_factor = cinfo->comp_info[1].v_samp_factor = 2;
-      //cinfo->comp_info[2].h_samp_factor = cinfo->comp_info[2].v_samp_factor = 1;
       // Use separate quantization tables for each component
       cinfo->comp_info[1].quant_tbl_no = 1;
       cinfo->comp_info[2].quant_tbl_no = 2;
@@ -826,9 +822,6 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[2].quant_tbl_no = 1;
     cinfo->comp_info[1].dc_tbl_no = cinfo->comp_info[1].ac_tbl_no = 1;
     cinfo->comp_info[2].dc_tbl_no = cinfo->comp_info[2].ac_tbl_no = 1;
-    // Subsampling is only useful at low qualities. Check added elsewhere.
-    // Use chroma subsampling by default
-    //cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
     if (colorspace == JCS_YCCK) {
       cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
     }

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -783,8 +783,8 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     default:
       JPEGLI_ERROR("Unsupported jpeg colorspace %d", colorspace);
   }
-  // Adobe marker is only needed to distinguish CMYK and YCCK JPEGs.
-  cinfo->write_Adobe_marker = TO_JXL_BOOL(cinfo->jpeg_color_space == JCS_YCCK);
+ // Adobe marker is needed to distinguish CMYK, YCCK and RGB(XYB) JPEGs.
+  cinfo->write_Adobe_marker = TO_JXL_BOOL((cinfo->jpeg_color_space == JCS_YCCK || cinfo->master->xyb_mode));
   if (cinfo->comp_info == nullptr) {
     cinfo->comp_info =
         jpegli::Allocate<jpeg_component_info>(cinfo, MAX_COMPONENTS);
@@ -807,9 +807,9 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[2].component_id = 'B';
     if (cinfo->master->xyb_mode) {
       // Subsample blue channel.
-      cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
-      cinfo->comp_info[1].h_samp_factor = cinfo->comp_info[1].v_samp_factor = 2;
-      cinfo->comp_info[2].h_samp_factor = cinfo->comp_info[2].v_samp_factor = 1;
+      //cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
+      //cinfo->comp_info[1].h_samp_factor = cinfo->comp_info[1].v_samp_factor = 2;
+      //cinfo->comp_info[2].h_samp_factor = cinfo->comp_info[2].v_samp_factor = 1;
       // Use separate quantization tables for each component
       cinfo->comp_info[1].quant_tbl_no = 1;
       cinfo->comp_info[2].quant_tbl_no = 2;
@@ -826,7 +826,7 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[1].dc_tbl_no = cinfo->comp_info[1].ac_tbl_no = 1;
     cinfo->comp_info[2].dc_tbl_no = cinfo->comp_info[2].ac_tbl_no = 1;
     // Use chroma subsampling by default
-    cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
+    //cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
     if (colorspace == JCS_YCCK) {
       cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
     }

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -717,65 +717,6 @@ void jpegli_set_defaults(j_compress_ptr cinfo) {
                                    /*is_dc=*/true);
 }
 
-bool auto420 = false;
-bool q100RGB = false;
-
-void jpegli_set_distance(j_compress_ptr cinfo, float distance,
-                         boolean force_baseline) {
-  CheckState(cinfo, jpegli::kEncStart);
-  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
-  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
-  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/true);
-  if (distance >= 6.4) {
-	  auto420 = true;
-  }
-  // At quality 100 (distance 0) auto select RGB colorspace.
-  if (distance == 0) {
-	  q100RGB = true;
-  }
-}
-
-float jpegli_quality_to_distance(int quality) {
-  return (quality >= 100  ? 0.01f
-          : quality >= 30 ? 0.1f + (100 - quality) * 0.09f
-                          : 53.0f / 3000.0f * quality * quality -
-                                23.0f / 20.0f * quality + 25.0f);
-}
-
-void jpegli_set_psnr(j_compress_ptr cinfo, float psnr, float tolerance,
-                     float min_distance, float max_distance) {
-  CheckState(cinfo, jpegli::kEncStart);
-  cinfo->master->psnr_target = psnr;
-  cinfo->master->psnr_tolerance = tolerance;
-  cinfo->master->min_distance = min_distance;
-  cinfo->master->max_distance = max_distance;
-}
-
-void jpegli_set_quality(j_compress_ptr cinfo, int quality,
-                        boolean force_baseline) {
-  CheckState(cinfo, jpegli::kEncStart);
-  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
-  float distance = jpegli_quality_to_distance(quality);
-  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
-  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
-  if (distance >= 6.4) {
-	  auto420 = true;
-  }
-  // At quality 100 (distance 0) auto select RGB colorspace.
-  if (distance == 0) {
-	  q100RGB = true;
-  }
-}
-
-void jpegli_set_linear_quality(j_compress_ptr cinfo, int scale_factor,
-                               boolean force_baseline) {
-  CheckState(cinfo, jpegli::kEncStart);
-  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
-  float distance = jpegli::LinearQualityToDistance(scale_factor);
-  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
-  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
-}
-
 void jpegli_default_colorspace(j_compress_ptr cinfo) {
   CheckState(cinfo, jpegli::kEncStart);
   if (cinfo->in_color_space == JCS_RGB && cinfo->master->xyb_mode) {
@@ -842,9 +783,9 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     default:
       JPEGLI_ERROR("Unsupported jpeg colorspace %d", colorspace);
   }
- // Adobe marker is needed to distinguish CMYK, YCCK and RGB(XYB) JPEGs.
+  // Adobe marker is needed to distinguish CMYK, YCCK and RGB(XYB) JPEGs.
   cinfo->write_Adobe_marker = TO_JXL_BOOL((cinfo->jpeg_color_space == JCS_CMYK ||
-    cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_RGB));
+  cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_RGB));
   if (cinfo->comp_info == nullptr) {
     cinfo->comp_info =
         jpegli::Allocate<jpeg_component_info>(cinfo, MAX_COMPONENTS);
@@ -855,7 +796,7 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     jpeg_component_info* comp = &cinfo->comp_info[c];
     comp->component_index = c;
     comp->component_id = c + 1;
-    // Default is no chroma subsampling.
+	// Default is no chroma subsampling.
     comp->h_samp_factor = 1;
     comp->v_samp_factor = 1;
     comp->quant_tbl_no = 0;
@@ -867,9 +808,9 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[1].component_id = 'G';
     cinfo->comp_info[2].component_id = 'B';
     if (cinfo->master->xyb_mode) {
-    // Use separate quantization tables for each component
-    cinfo->comp_info[1].quant_tbl_no = 1;
-    cinfo->comp_info[2].quant_tbl_no = 2;
+      // Use separate quantization tables for each component
+      cinfo->comp_info[1].quant_tbl_no = 1;
+      cinfo->comp_info[2].quant_tbl_no = 2;
     }
   } else if (colorspace == JCS_CMYK) {
     cinfo->comp_info[0].component_id = 'C';
@@ -882,15 +823,76 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[2].quant_tbl_no = 1;
     cinfo->comp_info[1].dc_tbl_no = cinfo->comp_info[1].ac_tbl_no = 1;
     cinfo->comp_info[2].dc_tbl_no = cinfo->comp_info[2].ac_tbl_no = 1;
-    // At low qualities, 420 subsampling begins to outperform 444.
-    // Therefore it's enabled by default.
-    if (auto420) {
+    // Use chroma subsampling by default
     cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
-      if (colorspace == JCS_YCCK) {
+    if (colorspace == JCS_YCCK) {
       cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
-      }
     }
   }
+}
+
+void jpegli_set_distance(j_compress_ptr cinfo, float distance,
+                         boolean force_baseline) {
+  CheckState(cinfo, jpegli::kEncStart);
+  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
+  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
+  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/true);
+  if (distance >= 6.4 && !(cinfo->master->xyb_mode)) {
+	// At low qualities, 420 subsampling begins to outperform 444.
+    // Therefore it's enabled by default.
+    cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
+    }
+  // At quality 100 (distance 0) auto select RGB colorspace.
+  // Disable adaptive quantization since it's unnecessary.
+  if (distance < 0.02f) {
+	  jpegli_set_colorspace(cinfo, JCS_RGB);
+	  cinfo->master->use_adaptive_quantization = false;
+  }
+}
+
+float jpegli_quality_to_distance(int quality) {
+  return (quality >= 100  ? 0.00f
+          : quality >= 30 ? 0.1f + (100 - quality) * 0.09f
+                          : 53.0f / 3000.0f * quality * quality -
+                                23.0f / 20.0f * quality + 25.0f);
+}
+
+void jpegli_set_psnr(j_compress_ptr cinfo, float psnr, float tolerance,
+                     float min_distance, float max_distance) {
+  CheckState(cinfo, jpegli::kEncStart);
+  cinfo->master->psnr_target = psnr;
+  cinfo->master->psnr_tolerance = tolerance;
+  cinfo->master->min_distance = min_distance;
+  cinfo->master->max_distance = max_distance;
+}
+
+void jpegli_set_quality(j_compress_ptr cinfo, int quality,
+                        boolean force_baseline) {
+  CheckState(cinfo, jpegli::kEncStart);
+  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
+  float distance = jpegli_quality_to_distance(quality);
+  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
+  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
+  if (distance >= 6.4 && !(cinfo->master->xyb_mode)) {
+	// At low qualities, 420 subsampling begins to outperform 444.
+    // Therefore it's enabled by default.
+    cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
+    }
+  // At quality 100 (distance 0) auto select RGB colorspace.
+  // Disable adaptive quantization since it's unnecessary.
+  if (distance < 0.02f) {
+	  jpegli_set_colorspace(cinfo, JCS_RGB);
+	  cinfo->master->use_adaptive_quantization = false;
+  }
+}
+
+void jpegli_set_linear_quality(j_compress_ptr cinfo, int scale_factor,
+                               boolean force_baseline) {
+  CheckState(cinfo, jpegli::kEncStart);
+  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
+  float distance = jpegli::LinearQualityToDistance(scale_factor);
+  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
+  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
 }
 
 #if JPEG_LIB_VERSION >= 70

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -839,7 +839,7 @@ void jpegli_set_distance(j_compress_ptr cinfo, float distance,
     }
   }
   // Disable adaptive quantization at high qualities.
-  if (distance <= 1.0f) {
+  if (distance <= 1.0f && !(cinfo->master->xyb_mode)) {
       cinfo->master->use_adaptive_quantization = false;
   }
   // At quality 100 (distance 0) auto select RGB colorspace.
@@ -880,7 +880,7 @@ void jpegli_set_quality(j_compress_ptr cinfo, int quality,
     }
   }
   // Disable adaptive quantization at high qualities.
-  if (distance <= 1.0f) {
+  if (distance <= 1.0f && !(cinfo->master->xyb_mode)) {
       cinfo->master->use_adaptive_quantization = false;
   }
   // At quality 100 (distance 0) auto select RGB colorspace.

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -823,11 +823,6 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[2].quant_tbl_no = 1;
     cinfo->comp_info[1].dc_tbl_no = cinfo->comp_info[1].ac_tbl_no = 1;
     cinfo->comp_info[2].dc_tbl_no = cinfo->comp_info[2].ac_tbl_no = 1;
-    // Use chroma subsampling by default
-    cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
-    if (colorspace == JCS_YCCK) {
-      cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
-    }
   }
 }
 
@@ -835,19 +830,21 @@ void jpegli_set_distance(j_compress_ptr cinfo, float distance,
                          boolean force_baseline) {
   CheckState(cinfo, jpegli::kEncStart);
   cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
-  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
-  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/true);
-  if (distance >= 6.4 && !(cinfo->master->xyb_mode)) {
-    // At low qualities, 420 subsampling begins to outperform 444.
-    // Therefore it's enabled by default.
+  if (distance >= 1.9f && !(cinfo->master->xyb_mode) &&
+    !cinfo->master->chroma_subsampling_set_by_cli) {
+    // At medium qualities, 420 subsampling begins to outperform 444.
     cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
     }
-  // At quality 100 (distance 0) auto select RGB colorspace.
-  // Disable adaptive quantization since it's unnecessary.
-  if (distance < 0.01f && cinfo->in_color_space == JCS_RGB) {
-	  jpegli_set_colorspace(cinfo, JCS_RGB);
-	  cinfo->master->use_adaptive_quantization = false;
+  // Disable adaptive quantization at high qualities.
+  if (distance <= 1.0f) {
+      cinfo->master->use_adaptive_quantization = false;
   }
+  // At quality 100 (distance 0) auto select RGB colorspace.
+  if (distance <= 0.01f && cinfo->in_color_space == JCS_RGB) {
+      jpegli_set_colorspace(cinfo, JCS_RGB);
+  }
+  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
+  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/true);
 }
 
 float jpegli_quality_to_distance(int quality) {
@@ -871,19 +868,21 @@ void jpegli_set_quality(j_compress_ptr cinfo, int quality,
   CheckState(cinfo, jpegli::kEncStart);
   cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
   float distance = jpegli_quality_to_distance(quality);
-  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
-  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
-  if (distance >= 6.4 && !(cinfo->master->xyb_mode)) {
-    // At low qualities, 420 subsampling begins to outperform 444.
-    // Therefore it's enabled by default.
+  if (distance >= 1.9f && !(cinfo->master->xyb_mode) &&
+    !cinfo->master->chroma_subsampling_set_by_cli) {
+    // At medium qualities, 420 subsampling begins to outperform 444.
     cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
     }
-  // At quality 100 (distance 0) auto select RGB colorspace.
-  // Disable adaptive quantization since it's unnecessary.
-  if (distance < 0.01f && cinfo->in_color_space == JCS_RGB) {
-	  jpegli_set_colorspace(cinfo, JCS_RGB);
-	  cinfo->master->use_adaptive_quantization = false;
+  // Disable adaptive quantization at high qualities.
+  if (distance <= 1.0f) {
+      cinfo->master->use_adaptive_quantization = false;
   }
+  // At quality 100 (distance 0) auto select RGB colorspace.
+  if (distance <= 0.01f && cinfo->in_color_space == JCS_RGB) {
+      jpegli_set_colorspace(cinfo, JCS_RGB);
+  }
+  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
+  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
 }
 
 void jpegli_set_linear_quality(j_compress_ptr cinfo, int scale_factor,

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -806,6 +806,7 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[1].component_id = 'G';
     cinfo->comp_info[2].component_id = 'B';
     if (cinfo->master->xyb_mode) {
+      // Subsampling RGB JPEG is incompatible with JPEG XL transcoding.
       // Subsample blue channel.
       //cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
       //cinfo->comp_info[1].h_samp_factor = cinfo->comp_info[1].v_samp_factor = 2;
@@ -825,6 +826,7 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[2].quant_tbl_no = 1;
     cinfo->comp_info[1].dc_tbl_no = cinfo->comp_info[1].ac_tbl_no = 1;
     cinfo->comp_info[2].dc_tbl_no = cinfo->comp_info[2].ac_tbl_no = 1;
+    // Subsampling is only useful at low qualities. Check added elsewhere.
     // Use chroma subsampling by default
     //cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
     if (colorspace == JCS_YCCK) {

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -784,7 +784,7 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
       JPEGLI_ERROR("Unsupported jpeg colorspace %d", colorspace);
   }
  // Adobe marker is needed to distinguish CMYK, YCCK and RGB(XYB) JPEGs.
-  cinfo->write_Adobe_marker = TO_JXL_BOOL((cinfo->jpeg_color_space == JCS_YCCK || cinfo->master->xyb_mode));
+  cinfo->write_Adobe_marker = TO_JXL_BOOL((cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_RGB));
   if (cinfo->comp_info == nullptr) {
     cinfo->comp_info =
         jpegli::Allocate<jpeg_component_info>(cinfo, MAX_COMPONENTS);

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -834,7 +834,7 @@ void jpegli_set_distance(j_compress_ptr cinfo, float distance,
     !cinfo->master->chroma_subsampling_set_by_cli) {
     // At medium qualities, 420 subsampling begins to outperform 444.
 	cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
-    if (cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_CMYK) {
+    if (cinfo->jpeg_color_space == JCS_YCCK) {
     cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
     }
   }
@@ -875,7 +875,7 @@ void jpegli_set_quality(j_compress_ptr cinfo, int quality,
     !cinfo->master->chroma_subsampling_set_by_cli) {
     // At medium qualities, 420 subsampling begins to outperform 444.
 	cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
-    if (cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_CMYK) {
+    if (cinfo->jpeg_color_space == JCS_YCCK) {
     cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
     }
   }

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -784,7 +784,8 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
       JPEGLI_ERROR("Unsupported jpeg colorspace %d", colorspace);
   }
  // Adobe marker is needed to distinguish CMYK, YCCK and RGB(XYB) JPEGs.
-  cinfo->write_Adobe_marker = TO_JXL_BOOL((cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_RGB));
+  cinfo->write_Adobe_marker = TO_JXL_BOOL((cinfo->jpeg_color_space == JCS_CMYK ||
+    cinfo->jpeg_color_space == JCS_YCCK || cinfo->jpeg_color_space == JCS_RGB));
   if (cinfo->comp_info == nullptr) {
     cinfo->comp_info =
         jpegli::Allocate<jpeg_component_info>(cinfo, MAX_COMPONENTS);
@@ -795,21 +796,21 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     jpeg_component_info* comp = &cinfo->comp_info[c];
     comp->component_index = c;
     comp->component_id = c + 1;
+    // Default is no chroma subsampling.
     comp->h_samp_factor = 1;
     comp->v_samp_factor = 1;
     comp->quant_tbl_no = 0;
     comp->dc_tbl_no = 0;
     comp->ac_tbl_no = 0;
   }
-  // Subsampling is handled in lib/extras/enc/jpegli.cc#L438
   if (colorspace == JCS_RGB) {
     cinfo->comp_info[0].component_id = 'R';
     cinfo->comp_info[1].component_id = 'G';
     cinfo->comp_info[2].component_id = 'B';
     if (cinfo->master->xyb_mode) {
-      // Use separate quantization tables for each component
-      cinfo->comp_info[1].quant_tbl_no = 1;
-      cinfo->comp_info[2].quant_tbl_no = 2;
+    // Use separate quantization tables for each component
+    cinfo->comp_info[1].quant_tbl_no = 1;
+    cinfo->comp_info[2].quant_tbl_no = 2;
     }
   } else if (colorspace == JCS_CMYK) {
     cinfo->comp_info[0].component_id = 'C';
@@ -822,8 +823,14 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[2].quant_tbl_no = 1;
     cinfo->comp_info[1].dc_tbl_no = cinfo->comp_info[1].ac_tbl_no = 1;
     cinfo->comp_info[2].dc_tbl_no = cinfo->comp_info[2].ac_tbl_no = 1;
+    // At low quality, 420 subsampling begins to outperform 444.
+    float qDistance = jpegli_quality_to_distance(jpeg_settings.quality);
+    if (jpeg_settings.distance >= 6.4 ||
+    (jpeg_settings.quality > 0.0 && qDistance >= 6.4)) {
+    cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
     if (colorspace == JCS_YCCK) {
-      cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
+    cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
+    }
     }
   }
 }

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -796,7 +796,7 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     jpeg_component_info* comp = &cinfo->comp_info[c];
     comp->component_index = c;
     comp->component_id = c + 1;
-	// Default is no chroma subsampling.
+    // Default is no chroma subsampling.
     comp->h_samp_factor = 1;
     comp->v_samp_factor = 1;
     comp->quant_tbl_no = 0;
@@ -838,13 +838,13 @@ void jpegli_set_distance(j_compress_ptr cinfo, float distance,
   float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
   jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/true);
   if (distance >= 6.4 && !(cinfo->master->xyb_mode)) {
-	// At low qualities, 420 subsampling begins to outperform 444.
+    // At low qualities, 420 subsampling begins to outperform 444.
     // Therefore it's enabled by default.
     cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
     }
   // At quality 100 (distance 0) auto select RGB colorspace.
   // Disable adaptive quantization since it's unnecessary.
-  if (distance < 0.02f) {
+  if (distance < 0.01f && cinfo->in_color_space == JCS_RGB) {
 	  jpegli_set_colorspace(cinfo, JCS_RGB);
 	  cinfo->master->use_adaptive_quantization = false;
   }
@@ -874,13 +874,13 @@ void jpegli_set_quality(j_compress_ptr cinfo, int quality,
   float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
   jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
   if (distance >= 6.4 && !(cinfo->master->xyb_mode)) {
-	// At low qualities, 420 subsampling begins to outperform 444.
+    // At low qualities, 420 subsampling begins to outperform 444.
     // Therefore it's enabled by default.
     cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
     }
   // At quality 100 (distance 0) auto select RGB colorspace.
   // Disable adaptive quantization since it's unnecessary.
-  if (distance < 0.02f) {
+  if (distance < 0.01f && cinfo->in_color_space == JCS_RGB) {
 	  jpegli_set_colorspace(cinfo, JCS_RGB);
 	  cinfo->master->use_adaptive_quantization = false;
   }

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -717,6 +717,65 @@ void jpegli_set_defaults(j_compress_ptr cinfo) {
                                    /*is_dc=*/true);
 }
 
+bool auto420 = false;
+bool q100RGB = false;
+
+void jpegli_set_distance(j_compress_ptr cinfo, float distance,
+                         boolean force_baseline) {
+  CheckState(cinfo, jpegli::kEncStart);
+  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
+  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
+  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/true);
+  if (distance >= 6.4) {
+	  auto420 = true;
+  }
+  // At quality 100 (distance 0) auto select RGB colorspace.
+  if (distance == 0) {
+	  q100RGB = true;
+  }
+}
+
+float jpegli_quality_to_distance(int quality) {
+  return (quality >= 100  ? 0.01f
+          : quality >= 30 ? 0.1f + (100 - quality) * 0.09f
+                          : 53.0f / 3000.0f * quality * quality -
+                                23.0f / 20.0f * quality + 25.0f);
+}
+
+void jpegli_set_psnr(j_compress_ptr cinfo, float psnr, float tolerance,
+                     float min_distance, float max_distance) {
+  CheckState(cinfo, jpegli::kEncStart);
+  cinfo->master->psnr_target = psnr;
+  cinfo->master->psnr_tolerance = tolerance;
+  cinfo->master->min_distance = min_distance;
+  cinfo->master->max_distance = max_distance;
+}
+
+void jpegli_set_quality(j_compress_ptr cinfo, int quality,
+                        boolean force_baseline) {
+  CheckState(cinfo, jpegli::kEncStart);
+  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
+  float distance = jpegli_quality_to_distance(quality);
+  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
+  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
+  if (distance >= 6.4) {
+	  auto420 = true;
+  }
+  // At quality 100 (distance 0) auto select RGB colorspace.
+  if (distance == 0) {
+	  q100RGB = true;
+  }
+}
+
+void jpegli_set_linear_quality(j_compress_ptr cinfo, int scale_factor,
+                               boolean force_baseline) {
+  CheckState(cinfo, jpegli::kEncStart);
+  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
+  float distance = jpegli::LinearQualityToDistance(scale_factor);
+  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
+  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
+}
+
 void jpegli_default_colorspace(j_compress_ptr cinfo) {
   CheckState(cinfo, jpegli::kEncStart);
   if (cinfo->in_color_space == JCS_RGB && cinfo->master->xyb_mode) {
@@ -823,58 +882,15 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
     cinfo->comp_info[2].quant_tbl_no = 1;
     cinfo->comp_info[1].dc_tbl_no = cinfo->comp_info[1].ac_tbl_no = 1;
     cinfo->comp_info[2].dc_tbl_no = cinfo->comp_info[2].ac_tbl_no = 1;
-    // At low quality, 420 subsampling begins to outperform 444.
-    float qDistance = jpegli_quality_to_distance(jpeg_settings.quality);
-    if (jpeg_settings.distance >= 6.4 ||
-    (jpeg_settings.quality > 0.0 && qDistance >= 6.4)) {
+    // At low qualities, 420 subsampling begins to outperform 444.
+    // Therefore it's enabled by default.
+    if (auto420) {
     cinfo->comp_info[0].h_samp_factor = cinfo->comp_info[0].v_samp_factor = 2;
-    if (colorspace == JCS_YCCK) {
-    cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
-    }
+      if (colorspace == JCS_YCCK) {
+      cinfo->comp_info[3].h_samp_factor = cinfo->comp_info[3].v_samp_factor = 2;
+      }
     }
   }
-}
-
-void jpegli_set_distance(j_compress_ptr cinfo, float distance,
-                         boolean force_baseline) {
-  CheckState(cinfo, jpegli::kEncStart);
-  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
-  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
-  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/true);
-}
-
-float jpegli_quality_to_distance(int quality) {
-  return (quality >= 100  ? 0.01f
-          : quality >= 30 ? 0.1f + (100 - quality) * 0.09f
-                          : 53.0f / 3000.0f * quality * quality -
-                                23.0f / 20.0f * quality + 25.0f);
-}
-
-void jpegli_set_psnr(j_compress_ptr cinfo, float psnr, float tolerance,
-                     float min_distance, float max_distance) {
-  CheckState(cinfo, jpegli::kEncStart);
-  cinfo->master->psnr_target = psnr;
-  cinfo->master->psnr_tolerance = tolerance;
-  cinfo->master->min_distance = min_distance;
-  cinfo->master->max_distance = max_distance;
-}
-
-void jpegli_set_quality(j_compress_ptr cinfo, int quality,
-                        boolean force_baseline) {
-  CheckState(cinfo, jpegli::kEncStart);
-  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
-  float distance = jpegli_quality_to_distance(quality);
-  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
-  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
-}
-
-void jpegli_set_linear_quality(j_compress_ptr cinfo, int scale_factor,
-                               boolean force_baseline) {
-  CheckState(cinfo, jpegli::kEncStart);
-  cinfo->master->force_baseline = FROM_JXL_BOOL(force_baseline);
-  float distance = jpegli::LinearQualityToDistance(scale_factor);
-  float distances[NUM_QUANT_TBLS] = {distance, distance, distance};
-  jpegli::SetQuantMatrices(cinfo, distances, /*add_two_chroma_tables=*/false);
 }
 
 #if JPEG_LIB_VERSION >= 70

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -75,6 +75,7 @@ struct jpeg_comp_master {
   uint8_t cicp_transfer_function;
   bool use_std_tables;
   bool use_adaptive_quantization;
+  bool chroma_subsampling_set_by_cli = false;
   int progressive_level;
   size_t xsize_blocks;
   size_t ysize_blocks;


### PR DESCRIPTION
### Description
The APP14 tag is now added to RGB(XYB), CMYK and YCCK JPEGs, as it is required in some decoders.
Using `--chroma_subsampling` will now correctly subsample XYB's Blue channel.
XYB is now 444 by default to allow JPEG XL Transcoding.
YCbCr now uses 444 by default and 420 at Quality 80/Distance 1.9 or lower.
Adaptive Quantization is disabled at Quality 90/Distance 1 or lower for non-XYB.
RGB is now used at Quality 100/Distance 0 for RGB input (PNG), overridden by XYB.

Fixes #122
Fixes https://github.com/libjxl/libjxl/issues/3512
Fixes https://github.com/libjxl/libjxl/issues/3605

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/google/jpegli/blob/main/CONTRIBUTING.md) for more details.
