### PR TITLE
allow empty DHT marker

### DIFF
--- a/lib/jpegli/bitstream.cc
+++ b/lib/jpegli/bitstream.cc
@@ -195,7 +195,7 @@ void EncodeDHT(j_compress_ptr cinfo, size_t offset, size_t num) {
     for (size_t j = 0; j <= kJpegHuffmanMaxBitLength; ++j) {
       marker_len += table.bits[j];
     }
-    // Special case: empty DHT markerAdd commentMore actions
+    // Special case: empty DHT marker
     if (marker_len == 2) break;
     marker_len += kJpegHuffmanMaxBitLength + 1;
   }

--- a/lib/jpegli/bitstream.cc
+++ b/lib/jpegli/bitstream.cc
@@ -192,10 +192,12 @@ void EncodeDHT(j_compress_ptr cinfo, size_t offset, size_t num) {
   for (size_t i = 0; i < num; ++i) {
     const JHUFF_TBL& table = m->huffman_tables[offset + i];
     if (table.sent_table) continue;
-    marker_len += kJpegHuffmanMaxBitLength + 1;
     for (size_t j = 0; j <= kJpegHuffmanMaxBitLength; ++j) {
       marker_len += table.bits[j];
     }
+    // Special case: empty DHT markerAdd commentMore actions
+    if (marker_len == 2) break;
+    marker_len += kJpegHuffmanMaxBitLength + 1;
   }
   std::vector<uint8_t> data(marker_len + 2);
   size_t pos = 0;
@@ -210,6 +212,8 @@ void EncodeDHT(j_compress_ptr cinfo, size_t offset, size_t num) {
     for (size_t i = 0; i <= kJpegHuffmanMaxBitLength; ++i) {
       total_count += table.bits[i];
     }
+    // Special case: empty DHT marker
+    if (total_count == 0) break;
     data[pos++] = m->slot_id_map[offset + t];
     for (size_t i = 1; i <= kJpegHuffmanMaxBitLength; ++i) {
       data[pos++] = table.bits[i];

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -285,9 +285,7 @@ void ProcessSOS(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
 void ProcessDHT(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
   size_t pos = 2;
   // Empty DHT marker.
-  if (pos == len) {
-    return ;
-  }
+  if (pos == len) return;
   while (pos < len) {
     JPEG_VERIFY_LEN(1 + kJpegHuffmanMaxBitLength);
     // The index of the Huffman code in the current set of Huffman codes. For AC

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -284,8 +284,9 @@ void ProcessSOS(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
 // and solt_id of Huffman code being read.
 void ProcessDHT(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
   size_t pos = 2;
+  // Empty DHT marker.
   if (pos == len) {
-    JPEGLI_ERROR("DHT marker: no Huffman table found");
+    return ;
   }
   while (pos < len) {
     JPEG_VERIFY_LEN(1 + kJpegHuffmanMaxBitLength);


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `jpegli`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

just migrate the "allow empty DHT marker" from libjxl to here.

related prs in libjxl
https://github.com/libjxl/libjxl/pull/2704
https://github.com/libjxl/libjxl/pull/4277

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/google/jpegli/blob/main/CONTRIBUTING.md) for more details.
