### PR TITLE
Support non-full-depth uint16 PNM input (10/12/14-bit)

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -66,10 +66,8 @@ Status VerifyInput(const PackedPixelFile& ppf) {
   JXL_RETURN_IF_ERROR(Encoder::VerifyBitDepth(image.format.data_type,
                                               info.bits_per_sample,
                                               info.exponent_bits_per_sample));
-  if ((image.format.data_type == JXL_TYPE_UINT8 && info.bits_per_sample != 8) ||
-      (image.format.data_type == JXL_TYPE_UINT16 &&
-       info.bits_per_sample != 16)) {
-    return JXL_FAILURE("Only full bit depth unsigned types are supported.");
+  if (image.format.data_type == JXL_TYPE_UINT8 && info.bits_per_sample != 8) {
+    return JXL_FAILURE("Only full bit depth uint8 type is supported.");
   }
   return true;
 }
@@ -391,6 +389,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
   unsigned char* output_buffer = nullptr;
   unsigned long output_size = 0;  // NOLINT
   std::vector<uint8_t> row_bytes;
+  std::vector<float> float_row;
   const size_t max_vector_size = MaxVectorSize();
   size_t rowlen = RoundUpTo(ppf.info.xsize, max_vector_size);
   hwy::AlignedFreeUniquePtr<float[]> xyb_tmp =
@@ -479,7 +478,11 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       cinfo.write_Adobe_marker = JXL_FALSE;
     }
     const PackedImage& image = ppf.frames[0].color;
-    if (jpeg_settings.xyb) {
+    const bool needs_float_conversion =
+        !jpeg_settings.xyb &&
+        image.format.data_type == JXL_TYPE_UINT16 &&
+        info.bits_per_sample != 16;
+    if (jpeg_settings.xyb || needs_float_conversion) {
       jpegli_set_input_format(&cinfo, JPEGLI_TYPE_FLOAT, JPEGLI_NATIVE_ENDIAN);
     } else {
       jpegli_set_input_format(&cinfo, ConvertDataType(image.format.data_type),
@@ -528,6 +531,28 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         }
         // feed to jpegli as native endian floats
         JSAMPROW row[] = {reinterpret_cast<uint8_t*>(row_out)};
+        jpegli_write_scanlines(&cinfo, row, 1);
+      }
+    } else if (needs_float_conversion) {
+      // Convert non-full-depth uint16 to float [0.0, 1.0] for jpegli.
+      const float scale = 1.0f / ((1u << info.bits_per_sample) - 1);
+      const bool is_little_endian =
+          (image.format.endianness == JXL_LITTLE_ENDIAN ||
+           (image.format.endianness == JXL_NATIVE_ENDIAN && IsLittleEndian()));
+      const size_t c_in = image.format.num_channels;
+      const size_t c_out = cinfo.num_components;
+      float_row.resize(info.xsize * c_out);
+      for (size_t y = 0; y < info.ysize; ++y) {
+        const uint8_t* row_in = pixels + y * image.stride;
+        for (size_t x = 0; x < info.xsize; ++x) {
+          for (size_t c = 0; c < c_out; ++c) {
+            const size_t ix = c_in * x + c;
+            uint16_t val = is_little_endian ? LoadLE16(&row_in[2 * ix])
+                                            : LoadBE16(&row_in[2 * ix]);
+            float_row[c_out * x + c] = val * scale;
+          }
+        }
+        JSAMPROW row[] = {reinterpret_cast<uint8_t*>(float_row.data())};
         jpegli_write_scanlines(&cinfo, row, 1);
       }
     } else {


### PR DESCRIPTION
The encoder rejected uint16 input unless bits_per_sample was exactly 16, causing failures for valid PGM files with maxval other than 65535 (e.g. 10-bit maxval=1023, 12-bit maxval=4095, 14-bit maxval=16383).

Fix by converting non-full-depth uint16 data to float with proper normalization (value / (2^N - 1)) before feeding to jpegli, which internally works in float anyway.

Tested with all 8-16 bit depth PNM files in testdata/:

$ for f in $(find testdata -type f \( -name "*.pgm" -o -name "*.ppm" -o -name "*.pnm" -o -name "*.pfm" -o -name "*.pam" \) | grep -vP '\.depth[1-7]\.' | sort); do ./build/tools/cjpegli "$f" "/tmp/$(basename ${f%.*}).jpg" -q 90; done Read 320x320 image, 1228816 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 20762 bytes (1.622 bpp).
320 x 320, 33.281 MP/s, 1 threads.
Read 2268x1512 image, 3429233 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 479651 bytes (1.119 bpp).
2268 x 1512, 69.906 MP/s, 1 threads.
Read 2268x1512 image, 10287665 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 588499 bytes (1.373 bpp).
2268 x 1512, 38.805 MP/s, 1 threads.
Read 510x532 image, 1085356 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42514 bytes (1.254 bpp).
510 x 532, 55.436 MP/s, 1 threads.
Read 510x532 image, 1085356 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42539 bytes (1.254 bpp).
510 x 532, 57.930 MP/s, 1 threads.
Read 510x532 image, 1085356 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42498 bytes (1.253 bpp).
510 x 532, 58.650 MP/s, 1 threads.
Read 510x532 image, 1085356 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42507 bytes (1.253 bpp).
510 x 532, 57.904 MP/s, 1 threads.
Read 510x532 image, 1085357 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42504 bytes (1.253 bpp).
510 x 532, 57.796 MP/s, 1 threads.
Read 510x532 image, 1085357 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42485 bytes (1.253 bpp).
510 x 532, 57.631 MP/s, 1 threads.
Read 510x532 image, 1085357 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42492 bytes (1.253 bpp).
510 x 532, 49.802 MP/s, 1 threads.
Read 510x532 image, 542715 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42492 bytes (1.253 bpp).
510 x 532, 50.964 MP/s, 1 threads.
Read 510x532 image, 1085355 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42551 bytes (1.255 bpp).
510 x 532, 56.318 MP/s, 1 threads.
Read 510x532 image, 542656 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42514 bytes (1.254 bpp).
510 x 532, 55.254 MP/s, 1 threads.
Read 510x532 image, 542656 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42539 bytes (1.254 bpp).
510 x 532, 57.512 MP/s, 1 threads.
Read 510x532 image, 542656 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42498 bytes (1.253 bpp).
510 x 532, 55.191 MP/s, 1 threads.
Read 510x532 image, 542656 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42507 bytes (1.253 bpp).
510 x 532, 57.439 MP/s, 1 threads.
Read 510x532 image, 542657 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42504 bytes (1.253 bpp).
510 x 532, 57.402 MP/s, 1 threads.
Read 510x532 image, 542657 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42485 bytes (1.253 bpp).
510 x 532, 57.802 MP/s, 1 threads.
Read 510x532 image, 542657 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42492 bytes (1.253 bpp).
510 x 532, 63.444 MP/s, 1 threads.
Read 510x532 image, 271335 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42492 bytes (1.253 bpp).
510 x 532, 65.117 MP/s, 1 threads.
Read 510x532 image, 542655 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 42551 bytes (1.255 bpp).
510 x 532, 56.888 MP/s, 1 threads.
Read 510x532 image, 2170630 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55546 bytes (1.638 bpp).
510 x 532, 32.474 MP/s, 1 threads.
Read 510x532 image, 2170630 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55536 bytes (1.638 bpp).
510 x 532, 31.938 MP/s, 1 threads.
Read 510x532 image, 2170630 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55508 bytes (1.637 bpp).
510 x 532, 32.667 MP/s, 1 threads.
Read 510x532 image, 2170630 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55515 bytes (1.637 bpp).
510 x 532, 32.037 MP/s, 1 threads.
Read 510x532 image, 2170631 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55507 bytes (1.637 bpp).
510 x 532, 32.238 MP/s, 1 threads.
Read 510x532 image, 2170631 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55527 bytes (1.637 bpp).
510 x 532, 31.883 MP/s, 1 threads.
Read 510x532 image, 2170631 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55540 bytes (1.638 bpp).
510 x 532, 31.580 MP/s, 1 threads.
Read 510x532 image, 1085349 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55540 bytes (1.638 bpp).
510 x 532, 31.792 MP/s, 1 threads.
Read 510x532 image, 2170629 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55458 bytes (1.635 bpp).
510 x 532, 31.598 MP/s, 1 threads.
Read 510x532 image, 1627936 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55546 bytes (1.638 bpp).
510 x 532, 31.344 MP/s, 1 threads.
Read 510x532 image, 1627936 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55536 bytes (1.638 bpp).
510 x 532, 32.518 MP/s, 1 threads.
Read 510x532 image, 1627936 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55508 bytes (1.637 bpp).
510 x 532, 32.627 MP/s, 1 threads.
Read 510x532 image, 1627936 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55515 bytes (1.637 bpp).
510 x 532, 32.560 MP/s, 1 threads.
Read 510x532 image, 1627937 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55507 bytes (1.637 bpp).
510 x 532, 32.853 MP/s, 1 threads.
Read 510x532 image, 1627937 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55527 bytes (1.637 bpp).
510 x 532, 32.485 MP/s, 1 threads.
Read 510x532 image, 1627937 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55540 bytes (1.638 bpp).
510 x 532, 35.257 MP/s, 1 threads.
Read 510x532 image, 813975 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55540 bytes (1.638 bpp).
510 x 532, 35.527 MP/s, 1 threads.
Read 510x532 image, 1627935 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 55458 bytes (1.635 bpp).
510 x 532, 33.397 MP/s, 1 threads.
Read 320x320 image, 1228816 bytes.
Encoding [YUV d1.000 AQ p2 OPT]
Compressed to 5167 bytes (0.404 bpp).
320 x 320, 46.631 MP/s, 1 threads.

<!-- Thank you for considering a contribution to `jpegli`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/google/jpegli/blob/main/CONTRIBUTING.md) for more details.
