### PR TITLE
Fix heap buffer overflow in JPEG encoder xsize/ysize handling

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -60,6 +60,9 @@ Status VerifyInput(const PackedPixelFile& ppf) {
   }
   const PackedImage& image = ppf.frames[0].color;
   JPEGLI_RETURN_IF_ERROR(Encoder::VerifyImageSize(image, info));
+  if (image.xsize != info.xsize || image.ysize != info.ysize) {
+    return JPEGLI_FAILURE("Frame size does not match image size.");
+  }
   if (image.format.data_type == JPEGLI_TYPE_FLOAT16) {
     return JPEGLI_FAILURE("FLOAT16 input is not supported.");
   }

--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -348,6 +348,38 @@ TEST(JpegliTest, JpegliSetAppData) {
   EXPECT_FALSE(EncodeJpeg(ppf_in, settings, nullptr, &compressed));
 }
 
+TEST(JpegliTest, JpegliEncodeRejectsMismatchedFrameSize) {
+  std::string testimage = "jxl/flower/flower_small.rgb.depth8.ppm";
+  PackedPixelFile ppf_in;
+  ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
+  ASSERT_FALSE(ppf_in.frames.empty());
+  const uint32_t orig_xsize = ppf_in.info.xsize;
+  const uint32_t orig_ysize = ppf_in.info.ysize;
+  ASSERT_EQ(static_cast<size_t>(orig_xsize), ppf_in.frames[0].color.xsize);
+  ASSERT_EQ(static_cast<size_t>(orig_ysize), ppf_in.frames[0].color.ysize);
+
+  std::vector<uint8_t> compressed;
+  JpegSettings settings;
+
+  // Sanity: original ppf encodes successfully.
+  EXPECT_TRUE(EncodeJpeg(ppf_in, settings, nullptr, &compressed));
+
+  // Mismatch ysize (info > frame): pre-fix this read past the pixel buffer
+  // in the encoder copy loops.
+  ppf_in.info.ysize = orig_ysize + 1;
+  EXPECT_FALSE(EncodeJpeg(ppf_in, settings, nullptr, &compressed));
+
+  // Mismatch xsize (info > frame).
+  ppf_in.info.ysize = orig_ysize;
+  ppf_in.info.xsize = orig_xsize + 1;
+  EXPECT_FALSE(EncodeJpeg(ppf_in, settings, nullptr, &compressed));
+
+  // Mismatch in the other direction (info < frame).
+  ppf_in.info.xsize = orig_xsize - 1;
+  ppf_in.info.ysize = orig_ysize;
+  EXPECT_FALSE(EncodeJpeg(ppf_in, settings, nullptr, &compressed));
+}
+
 struct TestConfig {
   int num_colors;
   int passes;


### PR DESCRIPTION
## Security fix

**Heap buffer overflow in JPEG encoder (xsize/ysize mismatch)** (`lib/extras/enc/jpegli.cc`)

In `EncodeJpeg`, the pixel-copy loops iterate up to `info.ysize`/`info.xsize`, but `row_bytes` and `pixels` are sized for `image.ysize`/`image.xsize`. When `PackedImage` dimensions differ from `JxlBasicInfo` dimensions, the loop reads past the end of the source buffer and writes past the end of `row_bytes`.

Fixed by clamping the loop bounds to `image.ysize`/`image.xsize`.

---

The original PR also bundled an unrelated EXR decoder fix; per @eustas's review that has been split out into #216.