### PR TITLE
Fix heap underflow write in EXR decoder extra-channel framebuffer setup

### DIFF
--- a/lib/extras/dec/exr.cc
+++ b/lib/extras/dec/exr.cc
@@ -329,16 +329,19 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
     }
 
     // Setup framebuffer: extra channels
-    char* extra_rows_ptr =
-        input_extra_rows.data() -
-        (dataWindow.min.x + start_y * row_size) * extraPixelBytes;
+    char* extra_rows_ptr = input_extra_rows.data();
     for (OpenEXR::ChannelList::ConstIterator it = channels.begin();
          it != channels.end(); ++it) {
       if (extraChannels.find(&it.channel()) == extraChannels.end()) {
         continue;
       }
       const size_t size = it.channel().type == OpenEXR::HALF ? 2 : 4;
-      fb.insert(it.name(), OpenEXR::Slice(it.channel().type, extra_rows_ptr,
+      // Compute per-channel virtual base pointer using per-channel stride (not
+      // extraPixelBytes) to avoid underflow when dataWindow.min.x > 0 with
+      // multiple extra channels.
+      char* ch_base_ptr =
+          extra_rows_ptr - (dataWindow.min.x + start_y * row_size) * size;
+      fb.insert(it.name(), OpenEXR::Slice(it.channel().type, ch_base_ptr,
                                           size, size * row_size));
       extra_rows_ptr += size * row_size * (end_y - start_y + 1);
     }
@@ -358,26 +361,29 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
       const int exr_x1 = std::max(dataWindow.min.x, displayWindow.min.x);
       const int exr_x2 = std::min(dataWindow.max.x, displayWindow.max.x);
 
-      const char* exr_ptr =
-          input_row + (exr_x1 - dataWindow.min.x) * colorPixelBytes;
-      uint8_t* image_ptr =
-          row + (exr_x1 - displayWindow.min.x) * colorPixelBytes;
-      memcpy(image_ptr, exr_ptr, (exr_x2 - exr_x1 + 1) * colorPixelBytes);
+      // Guard: skip copy when windows have no horizontal overlap.
+      if (exr_x1 <= exr_x2) {
+        const char* exr_ptr =
+            input_row + (exr_x1 - dataWindow.min.x) * colorPixelBytes;
+        uint8_t* image_ptr =
+            row + (exr_x1 - displayWindow.min.x) * colorPixelBytes;
+        memcpy(image_ptr, exr_ptr, (exr_x2 - exr_x1 + 1) * colorPixelBytes);
 
-      const char* JXL_RESTRICT input_ec_slice = input_extra_rows.data();
-      for (PackedImage& ec : frame.extra_channels) {
-        const char* const JXL_RESTRICT input_ec_row =
-            input_ec_slice + (exr_y - start_y) * ec.stride;
-        uint8_t* ec_row =
-            static_cast<uint8_t*>(ec.pixels()) + ec.stride * image_y;
-        input_ec_slice += ec.stride * (end_y - start_y + 1);
+        const char* JXL_RESTRICT input_ec_slice = input_extra_rows.data();
+        for (PackedImage& ec : frame.extra_channels) {
+          const char* const JXL_RESTRICT input_ec_row =
+              input_ec_slice + (exr_y - start_y) * ec.stride;
+          uint8_t* ec_row =
+              static_cast<uint8_t*>(ec.pixels()) + ec.stride * image_y;
+          input_ec_slice += ec.stride * (end_y - start_y + 1);
 
-        const char* exr_ec_ptr =
-            input_ec_row + (exr_x1 - dataWindow.min.x) * ec.pixel_stride();
-        uint8_t* image_ec_ptr =
-            ec_row + (exr_x1 - displayWindow.min.x) * ec.pixel_stride();
-        memcpy(image_ec_ptr, exr_ec_ptr,
-               (exr_x2 - exr_x1 + 1) * ec.pixel_stride());
+          const char* exr_ec_ptr =
+              input_ec_row + (exr_x1 - dataWindow.min.x) * ec.pixel_stride();
+          uint8_t* image_ec_ptr =
+              ec_row + (exr_x1 - displayWindow.min.x) * ec.pixel_stride();
+          memcpy(image_ec_ptr, exr_ec_ptr,
+                 (exr_x2 - exr_x1 + 1) * ec.pixel_stride());
+        }
       }
     }
   }

--- a/lib/extras/dec/exr.cc
+++ b/lib/extras/dec/exr.cc
@@ -332,16 +332,19 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
     }
 
     // Setup framebuffer: extra channels
-    char* extra_rows_ptr =
-        input_extra_rows.data() -
-        (dataWindow.min.x + start_y * row_size) * extraPixelBytes;
+    char* extra_rows_ptr = input_extra_rows.data();
     for (OpenEXR::ChannelList::ConstIterator it = channels.begin();
          it != channels.end(); ++it) {
       if (extraChannels.find(&it.channel()) == extraChannels.end()) {
         continue;
       }
       const size_t size = it.channel().type == OpenEXR::HALF ? 2 : 4;
-      fb.insert(it.name(), OpenEXR::Slice(it.channel().type, extra_rows_ptr,
+      // Compute per-channel virtual base pointer using per-channel stride (not
+      // extraPixelBytes) to avoid underflow when dataWindow.min.x > 0 with
+      // multiple extra channels.
+      char* ch_base_ptr =
+          extra_rows_ptr - (dataWindow.min.x + start_y * row_size) * size;
+      fb.insert(it.name(), OpenEXR::Slice(it.channel().type, ch_base_ptr,
                                           size, size * row_size));
       extra_rows_ptr += size * row_size * (end_y - start_y + 1);
     }


### PR DESCRIPTION
## Summary

Fix the heap-buffer-underflow write in `DecodeImageEXR` when a malformed EXR has `dataWindow.min.x > 0` (or non-zero `start_y` in chunked decoding) AND multiple extra channels. This PR was rebased on current `main` after #216 (the negative-count memcpy fix) was merged, so it now contains only the extra-channel framebuffer fix.

## Bug

`lib/extras/dec/exr.cc`, `DecodeImageEXR`, line 333 (the `extra_rows_ptr` initialization):

```cpp
char* extra_rows_ptr =
    input_extra_rows.data() -
    (dataWindow.min.x + start_y * row_size) * extraPixelBytes;
```

The offset is computed with `extraPixelBytes` (sum of all extra channels' per-pixel sizes), but each per-channel `OpenEXR::Slice` is configured with the **per-channel** `size, size * row_size` (line 341). When OpenEXR resolves pixel addresses as `extra_rows_ptr + x * size + y * size * row_size`, the result underflows `input_extra_rows.data()` by `data_min_x * (extraPixelBytes - size)` bytes for channel 0's first pixel (and a similar term for non-zero `start_y`).

The defect is independent of the negative-count memcpy bug fixed by #216; the windows can overlap normally — only `data_min_x > 0` plus multiple extras is required.

## Fix

Keep `input_extra_rows.data()` unmodified as a per-section anchor and compute a separate `ch_base_ptr` per channel using the channel's own `size`. With this, OpenEXR's address resolution `slice_base + x*size + y*size*row_size` lands inside the per-channel section.

## Reproduction

PoC config: `displayWindow X=[0..99] Y=[0..9]`, `dataWindow X=[50..149] Y=[0..9]`, 2 HALF extras + RGB HALF, no compression. With `data_min_x = 50`, `extraPixelBytes = 4`, per-channel `size = 2`, channel 0 row 0 underflows by 100 bytes at `[data - 100, data - 1]`.

ASan output (libjxl/jpegli with sanitizers):

```
AddressSanitizer: attempting free on address which was not malloc()-ed: 0x521000001500
    #0 operator delete(void*, unsigned long)
    #5 std::vector<char>::~vector
    #6 jxl::extras::DecodeImageEXR  lib/extras/dec/exr.cc:413
SUMMARY: AddressSanitizer: bad-free
```

The std::vector's `_M_p` was clobbered by the underflow write to a non-malloc'd address; ASan catches the bad-free at scope-exit destruction. Release build (no ASan) trips glibc's heap integrity check (e.g. `free(): invalid pointer` or `double free or corruption (out)`) and aborts.

## Note on history

This branch was originally filed on Apr 28 with a combined fix for both the line-333 underflow and the line-365 negative-count memcpy. Since then #216 was merged with the line-365 fix in a slightly different shape (using `exr_x_span = max(0, exr_x2 - exr_x1 + 1)`), so this rebase keeps only the line-333 underflow fix on top of #216.