### PR TITLE
docs: link ajpegli Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ When [building the project](doc/building_and_testing.md), two binaries,
 `lib/jpegli/libjpeg.so.62.3.0` shared library that can be used as a drop-in
 replacement for the system library with the same name.
 
+## Third-party Python package
+
+A third-party package, [ajpegli](https://github.com/dKosarevsky/ajpegli),
+provides JPEG-to-NumPy loading for Python using jpegli.
+
 ## Development process
 
 *   [More information on testing/build options](doc/building_and_testing.md)


### PR DESCRIPTION
## Summary
- add a small Python bindings section to README
- link ajpegli as a third-party jpegli-powered JPEG-to-NumPy package

## Testing
- git diff --check