### PR TITLE
fix off-by-one palette bounds check in gif non-replace branch

### DIFF
--- a/lib/extras/dec/gif.cc
+++ b/lib/extras/dec/gif.cc
@@ -377,7 +377,7 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
                          y * sub_frame_image.xsize;
         for (size_t x = 0; x < image_rect.xsize(); ++x, ++byte_index) {
           const GifByteType byte = image.RasterBits[byte_index];
-          if (byte > color_map->ColorCount) {
+          if (byte >= color_map->ColorCount) {
             return JPEGLI_FAILURE("GIF color is out of bounds");
           }
           if (byte == gcb.TransparentColor) {


### PR DESCRIPTION
The non-replace branch of DecodeImageGIF rejects a palette index byte using strict greater-than against ColorCount, but valid indices are 0..ColorCount-1. The sibling check on the replace branch already uses greater-or-equal. With byte equal to ColorCount, the subsequent Colors[byte] lookup reads one element past the heap-allocated palette and the OOB bytes flow into the output row. Same fix landed upstream as libjxl/libjxl#4778.