### PR TITLE
fix out-of-bounds read in EXR extra-channel row copy

### DIFF
--- a/lib/extras/dec/exr.cc
+++ b/lib/extras/dec/exr.cc
@@ -374,10 +374,10 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
         const char* JPEGLI_RESTRICT input_ec_slice = input_extra_rows.data();
         for (PackedImage& ec : frame.extra_channels) {
           const char* const JPEGLI_RESTRICT input_ec_row =
-              input_ec_slice + (exr_y - start_y) * ec.stride;
+              input_ec_slice + (exr_y - start_y) * ec.pixel_stride() * row_size;
           uint8_t* ec_row =
               static_cast<uint8_t*>(ec.pixels()) + ec.stride * image_y;
-          input_ec_slice += ec.stride * (end_y - start_y + 1);
+          input_ec_slice += ec.pixel_stride() * row_size * (end_y - start_y + 1);
 
           const char* exr_ec_ptr =
               input_ec_row + (exr_x1 - dataWindow.min.x) * ec.pixel_stride();


### PR DESCRIPTION
In DecodeImageEXR (lib/extras/dec/exr.cc) the extra-channel copy reads from the input_extra_rows scratch buffer using ec.stride, which is the display-window-wide output stride, but that buffer is filled by the OpenEXR framebuffer with the data-window row stride pixel_stride*row_size (row_size = dataWindow.size().x + 1). When displayWindow is wider than dataWindow the source pointer runs past the populated rows and reads out of bounds, copying heap data into the decoded extra channels. The color copy just above already uses the data-window stride; this makes the extra-channel source match.
