### PR TITLE
fix 32-bit overflow in ICC CICP tag-count bounds check

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -148,7 +148,7 @@ bool FindCICPTag(const uint8_t* icc_data, size_t len, bool is_first_chunk,
       return false;
     }
     uint32_t tag_count = LoadBE32(&icc_data[128]);
-    if (len < 132 + 12 * tag_count) {
+    if (len < 132 + static_cast<uint64_t>(12) * tag_count) {
       return false;
     }
     for (uint32_t i = 0; i < tag_count; ++i) {


### PR DESCRIPTION
`12 * tag_count` in FindCICPTag is computed in 32-bit, so a crafted ICC profile with tag_count=0x40000000 wraps `132 + 12 * tag_count` back to 132 and slips past the length guard. The loop then reads `icc_data[132 + 12*i]` past the end of the profile. tag_count comes from offset 128 of the embedded profile, which is attacker-controlled when transcoding an image. Widen the multiply to 64-bit.