### PR TITLE
fix off-by-one quant table index check in jpegli_add_quant_table

### DIFF
--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -906,7 +906,7 @@ void jpegli_add_quant_table(j_compress_ptr cinfo, int which_tbl,
                             const unsigned int* basic_table, int scale_factor,
                             boolean force_baseline) {
   CheckState(cinfo, jpegli::kEncStart);
-  if (which_tbl < 0 || which_tbl > NUM_QUANT_TBLS) {
+  if (which_tbl < 0 || which_tbl >= NUM_QUANT_TBLS) {
     JPEGLI_ERROR("Invalid quant table index %d", which_tbl);
   }
   if (cinfo->quant_tbl_ptrs[which_tbl] == nullptr) {

--- a/lib/jpegli/error_handling_test.cc
+++ b/lib/jpegli/error_handling_test.cc
@@ -292,6 +292,33 @@ TEST(EncoderErrorHandlingTest, InvalidQuantTableIndex) {
   if (buffer) free(buffer);
 }
 
+TEST(EncoderErrorHandlingTest, AddQuantTableInvalidIndex) {
+  uint8_t* buffer = nullptr;
+  unsigned long buffer_size = 0;  // NOLINT
+  jpeg_compress_struct cinfo;
+  const auto try_catch_block = [&]() -> bool {
+    ERROR_HANDLER_SETUP(jpegli);
+    jpegli_create_compress(&cinfo);
+    jpegli_mem_dest(&cinfo, &buffer, &buffer_size);
+    cinfo.image_width = 1;
+    cinfo.image_height = 1;
+    cinfo.input_components = 1;
+    jpegli_set_defaults(&cinfo);
+    unsigned int basic_table[DCTSIZE2];
+    for (unsigned int& v : basic_table) v = 1;
+    jpegli_add_quant_table(&cinfo, NUM_QUANT_TBLS, basic_table, 100, TRUE);
+    jpegli_start_compress(&cinfo, TRUE);
+    JSAMPLE image[1] = {0};
+    JSAMPROW row[] = {image};
+    jpegli_write_scanlines(&cinfo, row, 1);
+    jpegli_finish_compress(&cinfo);
+    return true;
+  };
+  EXPECT_FALSE(try_catch_block());
+  jpegli_destroy_compress(&cinfo);
+  if (buffer) free(buffer);
+}
+
 TEST(EncoderErrorHandlingTest, NumberOfComponentsMismatch1) {
   uint8_t* buffer = nullptr;
   unsigned long buffer_size = 0;  // NOLINT


### PR DESCRIPTION
### Description

`jpegli_add_quant_table` bounds-checks the caller-supplied `which_tbl` with `which_tbl > NUM_QUANT_TBLS` instead of `>=`, so `which_tbl == NUM_QUANT_TBLS` (4) slips through and the function then indexes `quant_tbl_ptrs[4]`, one past the four-entry array. In `jpeg_compress_struct` that read aliases `q_scale_factor[0]`, which `jpegli_set_defaults` initializes to 100, so the `== nullptr` check is skipped and 64 coefficients get written through `(JQUANT_TBL*)100`. Reachable through both this entry point and the libjpeg-compatible `jpeg_add_quant_table` wrapper.

Noticed comparing this setter to the decoder's DQT path (`decode_marker.cc`, `JPEG_VERIFY_INPUT(quant_table_index, 0, NUM_QUANT_TBLS - 1)`) and to libjpeg's `jcparam.c`, both of which bound the index at `NUM_QUANT_TBLS - 1`. The fix matches that. Added a regression test that calls the setter with `NUM_QUANT_TBLS` and expects a clean error rather than the out-of-bounds access.

### Pull Request Checklist

- [ ] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
