### PR TITLE
fix jdimension overflow in jpegli_crop_scanline bounds check

### DIFF
--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -939,7 +939,8 @@ void jpegli_crop_scanline(j_decompress_ptr cinfo, JDIMENSION* xoffset,
     JPEGLI_ERROR("Output cropping is not supported in raw data mode");
   }
   if (xoffset == nullptr || width == nullptr || *width == 0 ||
-      *xoffset + *width > cinfo->output_width) {
+      *xoffset >= cinfo->output_width ||
+      *width > cinfo->output_width - *xoffset) {
     JPEGLI_ERROR("jpegli_crop_scanline: Invalid arguments");
   }
   // TODO(szabadka) Skip the IDCT for skipped over blocks.

--- a/lib/jpegli/error_handling_test.cc
+++ b/lib/jpegli/error_handling_test.cc
@@ -1140,6 +1140,25 @@ TEST(DecoderErrorHandlingTest, NoReadScanlines) {
   jpegli_destroy_decompress(&cinfo);
 }
 
+TEST(DecoderErrorHandlingTest, CropScanlineArgumentOverflow) {
+  jpeg_decompress_struct cinfo = {};
+  const auto try_catch_block = [&]() -> bool {
+    ERROR_HANDLER_SETUP(jpegli);
+    jpegli_create_decompress(&cinfo);
+    jpegli_mem_src(&cinfo, kCompressed0, kLen0);
+    jpegli_read_header(&cinfo, TRUE);
+    jpegli_start_decompress(&cinfo);
+    // xoffset + width wraps around JDIMENSION and lands below output_width, so
+    // an unguarded sum accepts this out-of-range crop window.
+    JDIMENSION xoffset = 0xffffffffu;
+    JDIMENSION width = 2;
+    jpegli_crop_scanline(&cinfo, &xoffset, &width);
+    return true;
+  };
+  EXPECT_FALSE(try_catch_block());
+  jpegli_destroy_decompress(&cinfo);
+}
+
 const size_t kMaxImageWidth = 0xffff;
 JSAMPLE kOutputBuffer[MAX_COMPONENTS * kMaxImageWidth];
 


### PR DESCRIPTION
### Description

`*xoffset + *width` in `jpegli_crop_scanline` is computed in 32-bit `JDIMENSION`, so a large `*xoffset` wraps the sum below `output_width` and the bounds check accepts an out-of-range crop window; `master->xoffset_` is then left out of range and `WriteToOutput` reads the decoded component rows past their end, with the bytes landing in the caller's scanline buffer. found auditing the crop api. the check is rewritten to compare without the addition, which also covers the `jpeg_crop_scanline` wrapper, and a regression test is added.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
